### PR TITLE
214 collect usage stats

### DIFF
--- a/atramhasis/alembic/versions/1ad2b6fbcf22_visit_log.py
+++ b/atramhasis/alembic/versions/1ad2b6fbcf22_visit_log.py
@@ -1,0 +1,35 @@
+"""visit_log
+
+Revision ID: 1ad2b6fbcf22
+Revises: 441c5a16ef8
+Create Date: 2015-07-27 13:29:04.840631
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '1ad2b6fbcf22'
+down_revision = '441c5a16ef8'
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+    op.create_table('conceptscheme_visit_log',
+                    sa.Column('id', sa.Integer(), primary_key=True, autoincrement=True),
+                    sa.Column('conceptscheme_id', sa.String(), nullable=False),
+                    sa.Column('visited_at', sa.DateTime(), nullable=False),
+                    sa.Column('origin', sa.String, nullable=False)
+                    )
+    op.create_table('concept_visit_log',
+                    sa.Column('id', sa.Integer(), primary_key=True, autoincrement=True),
+                    sa.Column('concept_id', sa.Integer(), nullable=False),
+                    sa.Column('conceptscheme_id', sa.String(), nullable=False),
+                    sa.Column('visited_at', sa.DateTime(), nullable=False),
+                    sa.Column('origin', sa.String, nullable=False)
+                    )
+
+
+def downgrade():
+    op.drop_table('concept_visit_log')
+    op.drop_table('conceptscheme_visit_log')

--- a/atramhasis/audit.py
+++ b/atramhasis/audit.py
@@ -4,6 +4,9 @@ from atramhasis.data.models import (
     ConceptVisitLog
 )
 from pyramid.response import Response
+import logging
+
+log = logging.getLogger(__name__)
 
 
 def _origin_from_request(request):
@@ -59,6 +62,8 @@ def audit(fn):
                 concept_id=request.matchdict['c_id'],
                 conceptscheme_id=request.matchdict['scheme_id']
             )
+        elif 'scheme_id' not in request.matchdict.keys():
+            log.error('Misuse of the audit decorator. The url must at least contain a {scheme_id} parameter')
         else:
             visit_log = ConceptschemeVisitLog(conceptscheme_id=request.matchdict['scheme_id'])
         response = fn(parent_object, *args, **kw)

--- a/atramhasis/audit.py
+++ b/atramhasis/audit.py
@@ -41,9 +41,12 @@ def audit(fn):
     '''
     use this decorator to audit an operation and to log the visit
 
-    * rdf routes with .rdf, .ttl extensions have html accept mimetypes,
+    * CSV routes with .csv extensions accept all mime types,
+      the response is not of the `pyramid.response.Response` type,
+      the origin is derived from the `pyramid.request.Request.url` extension.
+    * RDF routes with .rdf, .ttl extensions accept all mime types,
       the origin is derived form the response content type.
-    * for REST and HTML the view results are not of the pyramid.response Response type,
+    * REST and HTML the view results are not of the `pyramid.response.Response` type,
       the origin is derived from the accept header.
     '''
 

--- a/atramhasis/audit.py
+++ b/atramhasis/audit.py
@@ -19,7 +19,7 @@ def _origin_from_request(request):
     elif 'application/json' in request.accept:
         return 'REST'
     else:
-        return 'onbekend'
+        return None
 
 
 def _origin_from_response(response):
@@ -34,7 +34,7 @@ def _origin_from_response(response):
     elif response.content_type == 'text/csv':
         return 'CSV'
     else:
-        return 'onbekend'
+        return None
 
 
 def audit(fn):

--- a/atramhasis/audit.py
+++ b/atramhasis/audit.py
@@ -1,0 +1,67 @@
+# -*- coding: utf-8 -*-
+from atramhasis.data.models import (
+    ConceptschemeVisitLog,
+    ConceptVisitLog
+)
+from pyramid.response import Response
+
+
+def _origin_from_request(request):
+    if 'text/html' in request.accept:
+        return 'HTML'
+    elif 'application/json' in request.accept:
+        return 'REST'
+    elif 'application/rdf+xml' in request.accept \
+            or 'text/turtle' in request.accept \
+            or 'application/x-turtle' in request.accept:
+        return 'RDF'
+    else:
+        return 'onbekend'
+
+
+def _origin_from_response(response):
+    if response.content_type == 'text/html':
+        return 'HTML'
+    elif response.content_type == 'application/json':
+        return 'REST'
+    elif response.content_type == 'application/rdf+xml' \
+            or response.content_type == 'text/turtle' \
+            or response.content_type == 'application/x-turtle':
+        return 'RDF'
+    else:
+        return 'onbekend'
+
+
+def audit(fn):
+    '''
+    use this decorator to audit an operation and to log the visit
+
+    * rdf routes with .rdf, .ttl extensions have html accept mimetypes,
+      the origin is derived form the response content type.
+    * for REST and HTML the view results are not of the pyramid.response Response type,
+      the origin is derived from the accept header.
+    '''
+
+    def advice(parent_object, *args, **kw):
+        request = parent_object.request
+        audit_manager = request.data_managers['audit_manager']
+
+        if 'c_id' in request.matchdict.keys():
+            visit_log = ConceptVisitLog(
+                concept_id=request.matchdict['c_id'],
+                conceptscheme_id=request.matchdict['scheme_id']
+            )
+        else:
+            visit_log = ConceptschemeVisitLog(conceptscheme_id=request.matchdict['scheme_id'])
+        response = fn(parent_object, *args, **kw)
+
+        if isinstance(response, Response):
+            visit_log.origin = _origin_from_response(response)
+        else:
+            visit_log.origin = _origin_from_request(request)
+
+        audit_manager.save(visit_log)
+
+        return response
+
+    return advice

--- a/atramhasis/audit.py
+++ b/atramhasis/audit.py
@@ -7,14 +7,17 @@ from pyramid.response import Response
 
 
 def _origin_from_request(request):
-    if 'text/html' in request.accept:
-        return 'HTML'
-    elif 'application/json' in request.accept:
-        return 'REST'
-    elif 'application/rdf+xml' in request.accept \
+    if request.url.endswith('.csv'):
+        return 'CSV'
+    elif request.url.endswith('.rdf') \
+            or 'application/rdf+xml' in request.accept \
             or 'text/turtle' in request.accept \
             or 'application/x-turtle' in request.accept:
         return 'RDF'
+    elif 'text/html' in request.accept:
+        return 'HTML'
+    elif 'application/json' in request.accept:
+        return 'REST'
     else:
         return 'onbekend'
 
@@ -28,6 +31,8 @@ def _origin_from_response(response):
             or response.content_type == 'text/turtle' \
             or response.content_type == 'application/x-turtle':
         return 'RDF'
+    elif response.content_type == 'text/csv':
+        return 'CSV'
     else:
         return 'onbekend'
 

--- a/atramhasis/audit.py
+++ b/atramhasis/audit.py
@@ -64,6 +64,7 @@ def audit(fn):
             )
         elif 'scheme_id' not in request.matchdict.keys():
             log.error('Misuse of the audit decorator. The url must at least contain a {scheme_id} parameter')
+            return fn(parent_object, *args, **kw)
         else:
             visit_log = ConceptschemeVisitLog(conceptscheme_id=request.matchdict['scheme_id'])
         response = fn(parent_object, *args, **kw)

--- a/atramhasis/data/datamanagers.py
+++ b/atramhasis/data/datamanagers.py
@@ -213,3 +213,19 @@ class LanguagesManager(DataManager):
 
     def count_languages(self, language_tag):
         return self.session.query(Language).filter_by(id=language_tag).count()
+
+
+class AuditManager(DataManager):
+    '''
+    A data manager for logging the visit.
+    '''
+
+    def save(self, visit_log):
+        '''
+        save a certain visit
+        :param visit_log: log of visit to save
+        :return: The saved visit log
+        '''
+        self.session.add(visit_log)
+        self.session.flush()
+        return visit_log

--- a/atramhasis/data/db.py
+++ b/atramhasis/data/db.py
@@ -2,7 +2,7 @@
 '''
 Module that sets up the datamanagers and the database connections.
 '''
-from atramhasis.data.datamanagers import SkosManager, ConceptSchemeManager, LanguagesManager
+from atramhasis.data.datamanagers import SkosManager, ConceptSchemeManager, LanguagesManager, AuditManager
 from .models import Base
 from skosprovider_sqlalchemy.models import Base as SkosBase
 
@@ -24,13 +24,14 @@ def data_managers(request):
     skos_manager = SkosManager(session)
     conceptscheme_manager = ConceptSchemeManager(session)
     languages_manager = LanguagesManager(session)
+    audit_manager = AuditManager(session)
 
     def cleanup(request):
         session.close()
     request.add_finished_callback(cleanup)
 
     return {'skos_manager': skos_manager, 'conceptscheme_manager': conceptscheme_manager,
-            'languages_manager': languages_manager}
+            'languages_manager': languages_manager, 'audit_manager': audit_manager}
 
 
 def includeme(config):

--- a/atramhasis/data/models.py
+++ b/atramhasis/data/models.py
@@ -1,3 +1,28 @@
 from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy import (
+    Column,
+    Integer,
+    String,
+    DateTime)
+from sqlalchemy.sql import (
+    func
+)
 
 Base = declarative_base()
+
+
+class ConceptschemeVisitLog(Base):
+    __tablename__ = 'conceptscheme_visit_log'
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    conceptscheme_id = Column(String(25), nullable=False)
+    visited_at = Column(DateTime, default=func.now(), nullable=False)
+    origin = Column(String(25), nullable=False)
+
+
+class ConceptVisitLog(Base):
+    __tablename__ = 'concept_visit_log'
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    concept_id = Column(Integer, nullable=False)
+    conceptscheme_id = Column(String(25), nullable=False)
+    visited_at = Column(DateTime, default=func.now(), nullable=False)
+    origin = Column(String(25), nullable=False)

--- a/atramhasis/routes.py
+++ b/atramhasis/routes.py
@@ -30,6 +30,8 @@ def includeme(config):
     config.add_route('scheme_root', pattern='/conceptschemes/{scheme_id}/c/', accept='text/html')
     config.add_route('scheme_tree', pattern='/conceptschemes/{scheme_id}/tree', accept='application/json')
     config.add_route('search_result_export', pattern='/conceptschemes/{scheme_id}/c.csv')
+    config.add_route('atramhasis.get_conceptscheme', pattern='/conceptschemes/{scheme_id}', accept='application/json',
+                     request_method="GET")
     config.add_route('atramhasis.get_concept', pattern='/conceptschemes/{scheme_id}/c/{c_id}',
                      accept='application/json', request_method="GET")
     config.add_route('atramhasis.add_concept', pattern='/conceptschemes/{scheme_id}/c', accept='application/json',

--- a/atramhasis/views/crud.py
+++ b/atramhasis/views/crud.py
@@ -16,6 +16,7 @@ from atramhasis.mappers import map_concept
 from atramhasis.protected_resources import protected_operation
 from atramhasis.utils import from_thing, internal_providers_only
 from atramhasis.views import invalidate_scheme_cache
+from atramhasis.audit import audit
 
 
 @view_defaults(accept='application/json', renderer='skosrenderer_verbose')
@@ -64,6 +65,14 @@ class AtramhasisCrud(object):
                 e.asdict()
             )
 
+    @audit
+    @view_config(route_name='atramhasis.get_conceptscheme', permission='view')
+    def get_conceptscheme(self):
+        # is the same as the pyramid_skosprovider get_conceptscheme function, but wrapped with the audit function
+        from pyramid_skosprovider.views import ProviderView
+        return ProviderView(self.request).get_conceptscheme()
+
+    @audit
     @view_config(route_name='atramhasis.get_concept', permission='view')
     def get_concept(self):
         '''

--- a/atramhasis/views/rdf.py
+++ b/atramhasis/views/rdf.py
@@ -3,6 +3,7 @@ from pyramid.view import view_defaults, view_config
 from skosprovider_rdf import utils
 
 from atramhasis.errors import SkosRegistryNotFoundException, ConceptSchemeNotFoundException
+from atramhasis.audit import audit
 
 
 @view_defaults()
@@ -21,6 +22,7 @@ class AtramhasisRDF(object):
         if not self.provider:
             raise ConceptSchemeNotFoundException(self.scheme_id)   # pragma: no cover
 
+    @audit
     @view_config(route_name='atramhasis.rdf_full_export')
     @view_config(route_name='atramhasis.rdf_full_export_ext')
     def rdf_full_export(self):
@@ -30,6 +32,7 @@ class AtramhasisRDF(object):
         response.content_disposition = 'attachment; filename="%s-full.rdf"' % (str(self.scheme_id),)
         return response
 
+    @audit
     @view_config(route_name='atramhasis.rdf_full_export_turtle')
     @view_config(route_name='atramhasis.rdf_full_export_turtle_x')
     @view_config(route_name='atramhasis.rdf_full_export_turtle_ext')
@@ -40,6 +43,7 @@ class AtramhasisRDF(object):
         response.content_disposition = 'attachment; filename="%s-full.ttl"' % (str(self.scheme_id),)
         return response
 
+    @audit
     @view_config(route_name='atramhasis.rdf_conceptscheme_export')
     @view_config(route_name='atramhasis.rdf_conceptscheme_export_ext')
     def rdf_conceptscheme_export(self):
@@ -59,6 +63,7 @@ class AtramhasisRDF(object):
         response.content_disposition = 'attachment; filename="%s.ttl"' % (str(self.scheme_id),)
         return response
 
+    @audit
     @view_config(route_name='atramhasis.rdf_individual_export')
     @view_config(route_name='atramhasis.rdf_individual_export_ext')
     def rdf_individual_export(self):
@@ -68,6 +73,7 @@ class AtramhasisRDF(object):
         response.content_disposition = 'attachment; filename="%s.rdf"' % (str(self.c_id),)
         return response
 
+    @audit
     @view_config(route_name='atramhasis.rdf_individual_export_turtle')
     @view_config(route_name='atramhasis.rdf_individual_export_turtle_x')
     @view_config(route_name='atramhasis.rdf_individual_export_turtle_ext')

--- a/atramhasis/views/views.py
+++ b/atramhasis/views/views.py
@@ -194,6 +194,7 @@ class AtramhasisView(object):
                             max_age=31536000)  # max_age = year
         return response
 
+    @audit
     @view_config(route_name='search_result_export', renderer='csv')
     def results_csv(self):
         header = ['conceptscheme', 'id', 'uri', 'type', 'label', 'prefLabels', 'altLabels', 'definition', 'broader',

--- a/atramhasis/views/views.py
+++ b/atramhasis/views/views.py
@@ -306,7 +306,6 @@ class AtramhasisListView(object):
         self.localizer = request.localizer
         self._ = TranslationStringFactory('atramhasis')
 
-    @audit
     @view_config(route_name='labeltypes')
     def labeltype_list_view(self):
         return self.get_list(LabelType)

--- a/atramhasis/views/views.py
+++ b/atramhasis/views/views.py
@@ -306,6 +306,7 @@ class AtramhasisListView(object):
         self.localizer = request.localizer
         self._ = TranslationStringFactory('atramhasis')
 
+    @audit
     @view_config(route_name='labeltypes')
     def labeltype_list_view(self):
         return self.get_list(LabelType)

--- a/atramhasis/views/views.py
+++ b/atramhasis/views/views.py
@@ -11,6 +11,7 @@ from skosprovider_sqlalchemy.models import Collection, Concept, LabelType, NoteT
 
 from atramhasis.errors import SkosRegistryNotFoundException, ConceptSchemeNotFoundException, ConceptNotFoundException
 from atramhasis.views import tree_region, invalidate_scheme_cache, invalidate_cache
+from atramhasis.audit import audit
 
 
 def labels_to_string(labels, ltype):
@@ -95,6 +96,7 @@ class AtramhasisView(object):
 
         return {'conceptschemes': conceptschemes}
 
+    @audit
     @view_config(route_name='conceptscheme', renderer='atramhasis:templates/conceptscheme.jinja2')
     def conceptscheme_view(self):
         '''
@@ -118,6 +120,7 @@ class AtramhasisView(object):
 
         return {'conceptscheme': scheme}
 
+    @audit
     @view_config(route_name='concept', renderer='atramhasis:templates/concept.jinja2')
     def concept_view(self):
         '''
@@ -284,7 +287,6 @@ class AtramhasisView(object):
             return str(concept_id)
         else:
             return parent_tree_id + "." + str(concept_id)
-
 
     @view_config(route_name='scheme_root', renderer='atramhasis:templates/concept.jinja2')
     def results_tree_html(self):

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -14,6 +14,7 @@ py==1.4.26
 coveralls==0.4.4
 webtest==2.0.16
 mock==1.0.1
+testfixtures==4.1.2
 
 # Documentation
 Sphinx==1.2.3

--- a/tests/test_audit.py
+++ b/tests/test_audit.py
@@ -1,0 +1,94 @@
+# -*- coding: utf-8 -*-
+import unittest
+from atramhasis.audit import audit, _origin_from_response
+from pyramid.response import Response
+
+try:
+    from unittest.mock import Mock, MagicMock
+except ImportError:
+    from mock import Mock, MagicMock, call  # pragma: no cover
+
+
+class RecordingManager(object):
+
+    def __init__(self):
+        self.saved_objects = []
+
+    def save(self, object):
+        self.saved_objects.append(object)
+
+
+class DummyParent(object):
+
+    def __init__(self):
+        self.request = MagicMock()
+
+    @audit
+    def dummy(self):
+        return None
+
+
+class AuditTests(unittest.TestCase):
+
+    def setUp(self):
+        self.audit_manager = RecordingManager()
+        self.dummy_parent = DummyParent()
+        self.dummy_parent.request.data_managers = {
+            'audit_manager': self.audit_manager
+        }
+
+    def tearDown(self):
+        pass
+
+    def _check(self, nr, origin, type_id_list):
+        self.assertEqual(nr, len(self.audit_manager.saved_objects))
+        self.assertEqual(origin, self.audit_manager.saved_objects[nr-1].origin)
+        for type_id in type_id_list:
+            self.assertEqual('1', getattr(self.audit_manager.saved_objects[nr-1], type_id))
+
+    def test_audit_rest(self):
+        self.dummy_parent.request.accept = ['application/json']
+        self.dummy_parent.request.matchdict = {'scheme_id': '1'}
+        self.dummy_parent.dummy()
+        self._check(1, 'REST', ['conceptscheme_id'])
+        self.dummy_parent.request.matchdict = {'scheme_id': '1', 'c_id': '1'}
+        self.dummy_parent.dummy()
+        self._check(2, 'REST', ['conceptscheme_id', 'concept_id'])
+
+    def test_audit_html(self):
+        self.dummy_parent.request.accept = ['text/html']
+        self.dummy_parent.request.matchdict = {'scheme_id': '1'}
+        self.dummy_parent.dummy()
+        self._check(1, 'HTML', ['conceptscheme_id'])
+        self.dummy_parent.request.matchdict = {'scheme_id': '1', 'c_id': '1'}
+        self.dummy_parent.dummy()
+        self._check(2, 'HTML', ['conceptscheme_id', 'concept_id'])
+
+    def test_audit_rdf_xml(self):
+        self.dummy_parent.request.accept = ['application/rdf+xml']
+        self.dummy_parent.request.matchdict = {'scheme_id': '1'}
+        self.dummy_parent.dummy()
+        self._check(1, 'RDF', ['conceptscheme_id'])
+        self.dummy_parent.request.matchdict = {'scheme_id': '1', 'c_id': '1'}
+        self.dummy_parent.dummy()
+        self._check(2, 'RDF', ['conceptscheme_id', 'concept_id'])
+
+    def test_audit_other(self):
+        self.dummy_parent.request.accept = ['application/octet-stream']
+        self.dummy_parent.request.matchdict = {'scheme_id': '1'}
+        self.dummy_parent.dummy()
+        self._check(1, 'onbekend', ['conceptscheme_id'])
+        self.dummy_parent.request.matchdict = {'scheme_id': '1', 'c_id': '1'}
+        self.dummy_parent.dummy()
+        self._check(2, 'onbekend', ['conceptscheme_id', 'concept_id'])
+
+    def test_origin_from_response(self):
+        res = Response(content_type='application/rdf+xml')
+        self.assertEqual('RDF', _origin_from_response(res))
+        res = Response(content_type='text/html')
+        self.assertEqual('HTML', _origin_from_response(res))
+        res = Response(content_type='application/json')
+        self.assertEqual('REST', _origin_from_response(res))
+        res = Response(content_type='application/octet-stream')
+        self.assertEqual('onbekend', _origin_from_response(res))
+

--- a/tests/test_audit.py
+++ b/tests/test_audit.py
@@ -91,10 +91,10 @@ class AuditTests(unittest.TestCase):
         self.dummy_parent.request.accept = ['application/octet-stream']
         self.dummy_parent.request.matchdict = {'scheme_id': '1'}
         self.dummy_parent.dummy()
-        self._check(1, 'onbekend', ['conceptscheme_id'])
+        self._check(1, None, ['conceptscheme_id'])
         self.dummy_parent.request.matchdict = {'scheme_id': '1', 'c_id': '1'}
         self.dummy_parent.dummy()
-        self._check(2, 'onbekend', ['conceptscheme_id', 'concept_id'])
+        self._check(2, None, ['conceptscheme_id', 'concept_id'])
 
     def test_origin_from_response(self):
         res = Response(content_type='application/rdf+xml')
@@ -106,5 +106,5 @@ class AuditTests(unittest.TestCase):
         res = Response(content_type='text/csv')
         self.assertEqual('CSV', _origin_from_response(res))
         res = Response(content_type='application/octet-stream')
-        self.assertEqual('onbekend', _origin_from_response(res))
+        self.assertIsNone(_origin_from_response(res))
 

--- a/tests/test_audit.py
+++ b/tests/test_audit.py
@@ -47,6 +47,7 @@ class AuditTests(unittest.TestCase):
             self.assertEqual('1', getattr(self.audit_manager.saved_objects[nr-1], type_id))
 
     def test_audit_rest(self):
+        self.dummy_parent.request.url = "http://host/conceptschemes/STYLES"
         self.dummy_parent.request.accept = ['application/json']
         self.dummy_parent.request.matchdict = {'scheme_id': '1'}
         self.dummy_parent.dummy()
@@ -56,6 +57,7 @@ class AuditTests(unittest.TestCase):
         self._check(2, 'REST', ['conceptscheme_id', 'concept_id'])
 
     def test_audit_html(self):
+        self.dummy_parent.request.url = "http://host/conceptschemes/STYLES"
         self.dummy_parent.request.accept = ['text/html']
         self.dummy_parent.request.matchdict = {'scheme_id': '1'}
         self.dummy_parent.dummy()
@@ -65,6 +67,7 @@ class AuditTests(unittest.TestCase):
         self._check(2, 'HTML', ['conceptscheme_id', 'concept_id'])
 
     def test_audit_rdf_xml(self):
+        self.dummy_parent.request.url = "http://host/conceptschemes/STYLES.rdf"
         self.dummy_parent.request.accept = ['application/rdf+xml']
         self.dummy_parent.request.matchdict = {'scheme_id': '1'}
         self.dummy_parent.dummy()
@@ -73,7 +76,18 @@ class AuditTests(unittest.TestCase):
         self.dummy_parent.dummy()
         self._check(2, 'RDF', ['conceptscheme_id', 'concept_id'])
 
+    def test_audit_csv(self):
+        self.dummy_parent.request.url = "http://host/conceptschemes/STYLES.csv"
+        self.dummy_parent.request.accept = "text/csv"
+        self.dummy_parent.request.matchdict = {'scheme_id': '1'}
+        self.dummy_parent.dummy()
+        self._check(1, 'CSV', ['conceptscheme_id'])
+        self.dummy_parent.request.matchdict = {'scheme_id': '1', 'c_id': '1'}
+        self.dummy_parent.dummy()
+        self._check(2, 'CSV', ['conceptscheme_id', 'concept_id'])
+
     def test_audit_other(self):
+        self.dummy_parent.request.url = "http://host/conceptschemes/STYLES"
         self.dummy_parent.request.accept = ['application/octet-stream']
         self.dummy_parent.request.matchdict = {'scheme_id': '1'}
         self.dummy_parent.dummy()
@@ -89,6 +103,8 @@ class AuditTests(unittest.TestCase):
         self.assertEqual('HTML', _origin_from_response(res))
         res = Response(content_type='application/json')
         self.assertEqual('REST', _origin_from_response(res))
+        res = Response(content_type='text/csv')
+        self.assertEqual('CSV', _origin_from_response(res))
         res = Response(content_type='application/octet-stream')
         self.assertEqual('onbekend', _origin_from_response(res))
 

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -22,6 +22,7 @@ from sqlalchemy import engine_from_config
 
 from atramhasis import includeme
 from atramhasis.data.db import data_managers
+from atramhasis.data.models import Base as VisitLogBase
 from atramhasis.protected_resources import ProtectedResourceException, ProtectedResourceEvent
 from fixtures.data import trees, geo, larch, chestnut, species
 from fixtures.materials import materials
@@ -120,6 +121,8 @@ class FunctionalTests(unittest.TestCase):
 
         Base.metadata.drop_all(self.engine)
         Base.metadata.create_all(self.engine)
+        VisitLogBase.metadata.drop_all(self.engine)
+        VisitLogBase.metadata.create_all(self.engine)
 
         Base.metadata.bind = self.engine
 

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -243,6 +243,12 @@ class RestFunctionalTests(FunctionalTests):
         self.assertEqual(res.json['id'], 1)
         self.assertEqual(res.json['type'], 'concept')
 
+    def test_get_conceptscheme(self):
+        res = self.testapp.get('/conceptschemes/TREES', headers=self._get_default_headers())
+        self.assertEqual('200 OK', res.status)
+        self.assertIn('application/json', res.headers['Content-Type'])
+        self.assertIsNotNone(res.json['id'])
+
     def test_get_concept_dictprovider(self):
         res = self.testapp.get('/conceptschemes/TEST/c/1', headers=self._get_default_headers())
         self.assertEqual('200 OK', res.status)

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -9,7 +9,7 @@ from sqlalchemy.orm.exc import NoResultFound
 from webob.multidict import MultiDict
 from paste.deploy.loadwsgi import appconfig
 
-from atramhasis.data.datamanagers import SkosManager, ConceptSchemeManager
+from atramhasis.data.datamanagers import SkosManager, ConceptSchemeManager, AuditManager
 from atramhasis.errors import SkosRegistryNotFoundException, ConceptSchemeNotFoundException, ConceptNotFoundException
 from atramhasis.views import tree_cache_dictionary
 from atramhasis.views.views import AtramhasisView, AtramhasisAdminView, AtramhasisListView, \
@@ -39,7 +39,12 @@ def data_managers(request):
     session_mock.query = Mock(side_effect=create_query_mock)
     skos_manager = SkosManager(session_mock)
     conceptscheme_manager = ConceptSchemeManager(session_mock)
-    return {'skos_manager': skos_manager, 'conceptscheme_manager': conceptscheme_manager}
+    audit_manager = AuditManager(session_mock)
+    return {
+        'skos_manager': skos_manager,
+        'conceptscheme_manager': conceptscheme_manager,
+        'audit_manager': audit_manager
+    }
 
 
 def create_query_mock(some_class):
@@ -125,7 +130,12 @@ def list_db(request):
     session_mock.query = Mock(side_effect=create_listquery_mock)
     skos_manager = SkosManager(session_mock)
     conceptscheme_manager = ConceptSchemeManager(session_mock)
-    return {'skos_manager': skos_manager, 'conceptscheme_manager': conceptscheme_manager}
+    audit_manager = AuditManager(session_mock)
+    return {
+        'skos_manager': skos_manager,
+        'conceptscheme_manager': conceptscheme_manager,
+        'audit_manager': audit_manager
+    }
 
 
 def create_listquery_mock(some_class):
@@ -146,7 +156,7 @@ class TestAtramhasisView(unittest.TestCase):
     def setUp(self):
         self.config = testing.setUp()
         self.request = testing.DummyRequest()
-        self.request.data_managers = {'skos_manager': None, 'conceptscheme_manager': None}
+        self.request.data_managers = {'skos_manager': None, 'conceptscheme_manager': None, 'audit_manager': None}
 
     def tearDown(self):
         testing.tearDown()
@@ -167,7 +177,7 @@ class TestHomeView(unittest.TestCase):
         self.regis = Registry()
         self.regis.register_provider(trees)
         self.request = testing.DummyRequest()
-        self.request.data_managers = {'skos_manager': None, 'conceptscheme_manager': None}
+        self.request.data_managers = {'skos_manager': None, 'conceptscheme_manager': None, 'audit_manager': None}
 
     def tearDown(self):
         testing.tearDown()
@@ -186,7 +196,7 @@ class TestFavicoView(unittest.TestCase):
         self.regis = Registry()
         self.regis.register_provider(trees)
         self.request = testing.DummyRequest()
-        self.request.data_managers = {'skos_manager': None, 'conceptscheme_manager': None}
+        self.request.data_managers = {'skos_manager': None, 'conceptscheme_manager': None, 'audit_manager': None}
 
     def tearDown(self):
         testing.tearDown()
@@ -206,6 +216,7 @@ class TestConceptSchemeView(unittest.TestCase):
         self.regis = Registry()
         self.regis.register_provider(trees)
         self.request = testing.DummyRequest()
+        self.request.accept = ['text/html']
         self.request.data_managers = data_managers(self.request)
         self.request.skos_registry = self.regis
 
@@ -239,6 +250,7 @@ class TestConceptView(unittest.TestCase):
     def setUp(self):
         self.config = testing.setUp()
         self.request = testing.DummyRequest()
+        self.request.accept = ['text/html']
         self.regis = Registry()
         self.regis.register_provider(provider(1))
         self.request.data_managers = data_managers(self.request)
@@ -312,7 +324,7 @@ class TestSearchResultView(unittest.TestCase):
         self.regis = Registry()
         self.regis.register_provider(trees)
         self.request = testing.DummyRequest()
-        self.request.data_managers = {'skos_manager': None, 'conceptscheme_manager': None}
+        self.request.data_managers = {'skos_manager': None, 'conceptscheme_manager': None, 'audit_manager': None}
 
     def tearDown(self):
         testing.tearDown()
@@ -416,7 +428,7 @@ class TestLocaleView(unittest.TestCase):
         config.add_route('home', 'foo')
         config.add_settings(settings)
         self.request = testing.DummyRequest()
-        self.request.data_managers = {'skos_manager': None, 'conceptscheme_manager': None}
+        self.request.data_managers = {'skos_manager': None, 'conceptscheme_manager': None, 'audit_manager': None}
 
     def tearDown(self):
         testing.tearDown()
@@ -474,7 +486,7 @@ class TestHtmlTreeView(unittest.TestCase):
         self.regis = Registry()
         self.regis.register_provider(trees)
         self.request = testing.DummyRequest()
-        self.request.data_managers = {'skos_manager': None, 'conceptscheme_manager': None}
+        self.request.data_managers = {'skos_manager': None, 'conceptscheme_manager': None, 'audit_manager': None}
 
     def tearDown(self):
         testing.tearDown()

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -378,6 +378,7 @@ class TestCsvView(unittest.TestCase):
     def setUp(self):
         self.config = testing.setUp()
         self.request = testing.DummyRequest()
+        self.request.accept = '*/*'
         self.regis = Registry()
         self.regis.register_provider(provider(1))
         self.request.skos_registry = self.regis

--- a/tox.ini
+++ b/tox.ini
@@ -6,6 +6,7 @@ deps =
 		pytest
 		webtest
         mock
+		testfixtures
 commands =
         pip install -r requirements-dev.txt
 		py.test
@@ -18,6 +19,7 @@ deps =
 		pytest-cov
 		webtest
 		mock
+		testfixtures
 commands =
         pip install -r requirements-dev.txt
 		py.test --cov atramhasis --cov-report term-missing tests


### PR DESCRIPTION
PR that fixes #214 

* Use of audit decorator to log the get requests of concepts and conceptschemes.
* Added primary key columns in visit log tables to be able to work with sqlAlchemy.
* Added conceptscheme_id and concept_id in concept_visit_log table.
* Retrieving the origin:
  * CSV routes with .csv extensions accept all mime types,
     the response is not of the `pyramid.response.Response` type,
     the origin is derived from the `pyramid.request.Request.url` extension.
  * RDF routes with .rdf, .ttl extensions accept all mime types,
    the origin is derived form the `pyramid.response.Response` content type.
  * REST and HTML view results are not of the `pyramid.response.Response` type,
     the origin is derived from the `pyramid.request.Request.accept`attribute.