### PR TITLE
Update application for skosprovider 0.7.0 and fix functional tests.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -101,4 +101,4 @@ atramhasis/scaffolds/atramhasis_scaffold/atramhasis-requirements-dev.txt_tmpl
 atramhasis/scaffolds/atramhasis_scaffold/atramhasis-requirements.txt_tmpl
 
 # sqlite database created for tests.
-tests/test.db
+test.db

--- a/.gitignore
+++ b/.gitignore
@@ -99,3 +99,6 @@ atramhasis/scaffolds/atramhasis_scaffold/+package+/static/scss/atramhasis
 atramhasis/scaffolds/atramhasis_scaffold/+package+/static/admin
 atramhasis/scaffolds/atramhasis_scaffold/atramhasis-requirements-dev.txt_tmpl
 atramhasis/scaffolds/atramhasis_scaffold/atramhasis-requirements.txt_tmpl
+
+# sqlite database created for tests.
+tests/test.db

--- a/atramhasis/__init__.py
+++ b/atramhasis/__init__.py
@@ -44,9 +44,4 @@ def main(global_config, **settings):
 
     config.include('atramhasis.data:db')
 
-    # if standalone include skos sample data
-    test_mode = settings.get('atramhasis.test_mode')
-    if not test_mode == 'true':  # pragma: no cover
-        config.include('.skos')
-
     return config.make_wsgi_app()

--- a/atramhasis/alembic/versions/cb568ec81000_add_infer_concept_relations_column.py
+++ b/atramhasis/alembic/versions/cb568ec81000_add_infer_concept_relations_column.py
@@ -15,7 +15,8 @@ down_revision = '184f1bbcb916'
 def upgrade():
     op.add_column(
         'concept',
-        sa.Column('infer_concept_relations', sa.Boolean(), nullable=True)
+        sa.Column('infer_concept_relations', sa.Boolean(), nullable=False,
+                  server_default=True)
     )
 
 

--- a/atramhasis/alembic/versions/cb568ec81000_add_infer_concept_relations_column.py
+++ b/atramhasis/alembic/versions/cb568ec81000_add_infer_concept_relations_column.py
@@ -1,0 +1,23 @@
+"""Add infer_concept_relations column.
+
+Revision ID: cb568ec81000
+Revises: 184f1bbcb916
+Create Date: 2020-02-19 09:29:17.619082
+"""
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = 'cb568ec81000'
+down_revision = '184f1bbcb916'
+
+
+def upgrade():
+    op.add_column(
+        'concept',
+        sa.Column('infer_concept_relations', sa.Boolean(), nullable=True)
+    )
+
+
+def downgrade():
+    op.drop_column('concept', 'infer_concept_relations')

--- a/atramhasis/alembic/versions/cb568ec81000_add_infer_concept_relations_column.py
+++ b/atramhasis/alembic/versions/cb568ec81000_add_infer_concept_relations_column.py
@@ -16,7 +16,7 @@ def upgrade():
     op.add_column(
         'concept',
         sa.Column('infer_concept_relations', sa.Boolean(), nullable=False,
-                  server_default=True)
+                  server_default='true')
     )
 
 

--- a/atramhasis/data/db.py
+++ b/atramhasis/data/db.py
@@ -20,18 +20,23 @@ def data_managers(request):
     :returns: A dictionary containing different
         :class:`datamanagers <atramhasis.data.datamanagers.DataManager>`.
     """
-    session = request.registry.dbmaker()
+    session = request.db
     skos_manager = SkosManager(session)
     conceptscheme_manager = ConceptSchemeManager(session)
     languages_manager = LanguagesManager(session)
     audit_manager = AuditManager(session)
 
-    def cleanup(request):
-        session.close()
-    request.add_finished_callback(cleanup)
-
     return {'skos_manager': skos_manager, 'conceptscheme_manager': conceptscheme_manager,
             'languages_manager': languages_manager, 'audit_manager': audit_manager}
+
+
+def db(request):
+    session = request.registry.dbmaker()
+
+    def cleanup(_):
+        session.close()
+    request.add_finished_callback(cleanup)
+    return session
 
 
 def includeme(config):
@@ -51,3 +56,4 @@ def includeme(config):
     )
     config.registry.dbmaker = session_maker
     config.add_request_method(data_managers, reify=True)
+    config.add_request_method(db, reify=True)

--- a/atramhasis/skos/__init__.py
+++ b/atramhasis/skos/__init__.py
@@ -23,170 +23,176 @@ LICENSES = [
 
 
 def create_registry(request):
-    registry = Registry(instance_scope='threaded_thread')
-    dataseturigenerator = UriPatternGenerator(
-        'https://id.erfgoed.net/datasets/thesauri/%s'
-    )
-
-    trees = SQLAlchemyProvider(
-        {'id': 'TREES', 'conceptscheme_id': 1},
-        request.db
-    )
-
-    geo = SQLAlchemyProvider(
-        {'id': 'GEOGRAPHY', 'conceptscheme_id': 2},
-        request.db
-    )
-
-    styles = SQLAlchemyProvider(
-        {
-            'id': 'STYLES',
-            'conceptscheme_id': 3,
-            'dataset': {
-                'uri': dataseturigenerator.generate(id='stijlen_en_culturen'),
-                'publisher': ['https://id.erfgoed.net/actoren/501'],
-                'created': [date(2008, 2, 14)],
-                'language': ['nl-BE'],
-                'license': LICENSES
-            }
-
-        },
-        request.db,
-        uri_generator=UriPatternGenerator(
-            'https://id.erfgoed.net/thesauri/stijlen_en_culturen/%s'
+    try:
+        registry = Registry(instance_scope='threaded_thread')
+        dataseturigenerator = UriPatternGenerator(
+            'https://id.erfgoed.net/datasets/thesauri/%s'
         )
-    )
 
-    materials = SQLAlchemyProvider(
-        {
-            'id': 'MATERIALS',
-            'conceptscheme_id': 4,
-            'dataset': {
-                'uri': dataseturigenerator.generate(id='materialen'),
-                'publisher': ['https://id.erfgoed.net/actoren/501'],
-                'created': [date(2011, 3, 16)],
-                'language': ['nl-BE'],
-                'license': LICENSES
-            }
-        },
-        request.db,
-        uri_generator=UriPatternGenerator('https://id.erfgoed.net/thesauri/materialen/%s')
-    )
-
-    eventtypes = SQLAlchemyProvider(
-        {
-            'id': 'EVENTTYPE',
-            'conceptscheme_id': 5,
-            'dataset': {
-                'uri': dataseturigenerator.generate(id='gebeurtenistypes'),
-                'publisher': ['https://id.erfgoed.net/actoren/501'],
-                'created': [date(2010, 8, 13)],
-                'language': ['nl-BE'],
-                'license': LICENSES
-            }
-        },
-        request.db,
-        uri_generator=UriPatternGenerator(
-            'https://id.erfgoed.net/thesauri/gebeurtenistypes/%s'
+        trees = SQLAlchemyProvider(
+            {'id': 'TREES', 'conceptscheme_id': 1},
+            request.db
         )
-    )
 
-    heritagetypes = SQLAlchemyProvider(
-        {
-            'id': 'HERITAGETYPE',
-            'conceptscheme_id': 6,
-            'dataset': {
-                'uri': dataseturigenerator.generate(id='erfgoedtypes'),
-                'publisher': ['https://id.erfgoed.net/actoren/501'],
-                'created': [date(2008, 2, 14)],
-                'language': ['nl-BE'],
-                'license': LICENSES
-            }
-        },
-        request.db,
-        uri_generator=UriPatternGenerator(
-            'https://id.erfgoed.net/thesauri/erfgoedtypes/%s'
+        geo = SQLAlchemyProvider(
+            {'id': 'GEOGRAPHY', 'conceptscheme_id': 2},
+            request.db
         )
-    )
 
-    periods = SQLAlchemyProvider(
-        {
-            'id': 'PERIOD',
-            'conceptscheme_id': 7,
-            'dataset': {
-                'uri': dataseturigenerator.generate(id='dateringen'),
-                'publisher': ['https://id.erfgoed.net/actoren/501'],
-                'created': [date(2008, 2, 14)],
-                'language': ['nl-BE'],
-                'license': LICENSES
-            }
-        },
-        request.db,
-        uri_generator=UriPatternGenerator('https://id.erfgoed.net/thesauri/dateringen/%s')
-    )
+        styles = SQLAlchemyProvider(
+            {
+                'id': 'STYLES',
+                'conceptscheme_id': 3,
+                'dataset': {
+                    'uri': dataseturigenerator.generate(id='stijlen_en_culturen'),
+                    'publisher': ['https://id.erfgoed.net/actoren/501'],
+                    'created': [date(2008, 2, 14)],
+                    'language': ['nl-BE'],
+                    'license': LICENSES
+                }
 
-    species = SQLAlchemyProvider(
-        {
-            'id': 'SPECIES',
-            'conceptscheme_id': 8,
-            'dataset': {
-                'uri': dataseturigenerator.generate(id='soorten'),
-                'publisher': ['https://id.erfgoed.net/actoren/501'],
-                'created': [date(2011, 5, 23)],
-                'language': ['nl-BE', 'la'],
-                'license': LICENSES
-            }
-        },
-        request.db,
-        uri_generator=UriPatternGenerator('https://id.erfgoed.net/thesauri/soorten/%s')
-    )
+            },
+            request.db,
+            uri_generator=UriPatternGenerator(
+                'https://id.erfgoed.net/thesauri/stijlen_en_culturen/%s'
+            )
+        )
 
-    # use 'subject': ['external'] for read only external providers
-    # (only available in REST service)
+        materials = SQLAlchemyProvider(
+            {
+                'id': 'MATERIALS',
+                'conceptscheme_id': 4,
+                'dataset': {
+                    'uri': dataseturigenerator.generate(id='materialen'),
+                    'publisher': ['https://id.erfgoed.net/actoren/501'],
+                    'created': [date(2011, 3, 16)],
+                    'language': ['nl-BE'],
+                    'license': LICENSES
+                }
+            },
+            request.db,
+            uri_generator=UriPatternGenerator(
+                'https://id.erfgoed.net/thesauri/materialen/%s'
+            )
+        )
 
-    getty_session = CacheControl(requests.Session(), heuristic=ExpiresAfter(weeks=1))
+        eventtypes = SQLAlchemyProvider(
+            {
+                'id': 'EVENTTYPE',
+                'conceptscheme_id': 5,
+                'dataset': {
+                    'uri': dataseturigenerator.generate(id='gebeurtenistypes'),
+                    'publisher': ['https://id.erfgoed.net/actoren/501'],
+                    'created': [date(2010, 8, 13)],
+                    'language': ['nl-BE'],
+                    'license': LICENSES
+                }
+            },
+            request.db,
+            uri_generator=UriPatternGenerator(
+                'https://id.erfgoed.net/thesauri/gebeurtenistypes/%s'
+            )
+        )
 
-    aat = AATProvider(
-        {'id': 'AAT', 'subject': ['external']},
-        session=getty_session
-    )
+        heritagetypes = SQLAlchemyProvider(
+            {
+                'id': 'HERITAGETYPE',
+                'conceptscheme_id': 6,
+                'dataset': {
+                    'uri': dataseturigenerator.generate(id='erfgoedtypes'),
+                    'publisher': ['https://id.erfgoed.net/actoren/501'],
+                    'created': [date(2008, 2, 14)],
+                    'language': ['nl-BE'],
+                    'license': LICENSES
+                }
+            },
+            request.db,
+            uri_generator=UriPatternGenerator(
+                'https://id.erfgoed.net/thesauri/erfgoedtypes/%s'
+            )
+        )
 
-    tgn = TGNProvider(
-        {'id': 'TGN', 'subject': ['external']},
-        session=getty_session
-    )
+        periods = SQLAlchemyProvider(
+            {
+                'id': 'PERIOD',
+                'conceptscheme_id': 7,
+                'dataset': {
+                    'uri': dataseturigenerator.generate(id='dateringen'),
+                    'publisher': ['https://id.erfgoed.net/actoren/501'],
+                    'created': [date(2008, 2, 14)],
+                    'language': ['nl-BE'],
+                    'license': LICENSES
+                }
+            },
+            request.db,
+            uri_generator=UriPatternGenerator('https://id.erfgoed.net/thesauri/dateringen/%s')
+        )
 
-    eh_session = CacheControl(requests.Session(), heuristic=ExpiresAfter(weeks=1))
+        species = SQLAlchemyProvider(
+            {
+                'id': 'SPECIES',
+                'conceptscheme_id': 8,
+                'dataset': {
+                    'uri': dataseturigenerator.generate(id='soorten'),
+                    'publisher': ['https://id.erfgoed.net/actoren/501'],
+                    'created': [date(2011, 5, 23)],
+                    'language': ['nl-BE', 'la'],
+                    'license': LICENSES
+                }
+            },
+            request.db,
+            uri_generator=UriPatternGenerator('https://id.erfgoed.net/thesauri/soorten/%s')
+        )
 
-    eh_period = HeritagedataProvider(
-        {'id': 'EH_PERIOD', 'subject': ['external']},
-        scheme_uri='http://purl.org/heritagedata/schemes/eh_period',
-        session=eh_session
-    )
+        # use 'subject': ['external'] for read only external providers
+        # (only available in REST service)
 
-    eh_monument_type = HeritagedataProvider(
-        {'id': 'EH_MONUMENT_TYPE', 'subject': ['external']},
-        scheme_uri='http://purl.org/heritagedata/schemes/eh_tmt2',
-        session=eh_session
-    )
+        getty_session = CacheControl(requests.Session(), heuristic=ExpiresAfter(weeks=1))
 
-    eh_materials = HeritagedataProvider(
-        {'id': 'EH_MATERIALS', 'subject': ['external']},
-        scheme_uri='http://purl.org/heritagedata/schemes/eh_tbm',
-        session=eh_session
-    )
+        aat = AATProvider(
+            {'id': 'AAT', 'subject': ['external']},
+            session=getty_session
+        )
 
-    registry.register_provider(trees)
-    registry.register_provider(geo)
-    registry.register_provider(styles)
-    registry.register_provider(materials)
-    registry.register_provider(eventtypes)
-    registry.register_provider(heritagetypes)
-    registry.register_provider(periods)
-    registry.register_provider(species)
-    registry.register_provider(aat)
-    registry.register_provider(tgn)
-    registry.register_provider(eh_period)
-    registry.register_provider(eh_monument_type)
-    registry.register_provider(eh_materials)
-    return registry
+        tgn = TGNProvider(
+            {'id': 'TGN', 'subject': ['external']},
+            session=getty_session
+        )
+
+        eh_session = CacheControl(requests.Session(), heuristic=ExpiresAfter(weeks=1))
+
+        eh_period = HeritagedataProvider(
+            {'id': 'EH_PERIOD', 'subject': ['external']},
+            scheme_uri='http://purl.org/heritagedata/schemes/eh_period',
+            session=eh_session
+        )
+
+        eh_monument_type = HeritagedataProvider(
+            {'id': 'EH_MONUMENT_TYPE', 'subject': ['external']},
+            scheme_uri='http://purl.org/heritagedata/schemes/eh_tmt2',
+            session=eh_session
+        )
+
+        eh_materials = HeritagedataProvider(
+            {'id': 'EH_MATERIALS', 'subject': ['external']},
+            scheme_uri='http://purl.org/heritagedata/schemes/eh_tbm',
+            session=eh_session
+        )
+
+        registry.register_provider(trees)
+        registry.register_provider(geo)
+        registry.register_provider(styles)
+        registry.register_provider(materials)
+        registry.register_provider(eventtypes)
+        registry.register_provider(heritagetypes)
+        registry.register_provider(periods)
+        registry.register_provider(species)
+        registry.register_provider(aat)
+        registry.register_provider(tgn)
+        registry.register_provider(eh_period)
+        registry.register_provider(eh_monument_type)
+        registry.register_provider(eh_materials)
+        return registry
+    except AttributeError:
+        log.exception("Attribute error during creation of Registry.")
+        raise

--- a/atramhasis/skos/__init__.py
+++ b/atramhasis/skos/__init__.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 
 import logging
+
+from skosprovider.registry import Registry
 from skosprovider.uri import UriPatternGenerator
 from skosprovider_sqlalchemy.providers import SQLAlchemyProvider
 
@@ -14,181 +16,177 @@ from cachecontrol.heuristics import ExpiresAfter
 from datetime import date
 
 log = logging.getLogger(__name__)
+LICENSES = [
+    'https://creativecommons.org/licenses/by/4.0/',
+    'http://data.vlaanderen.be/doc/licentie/modellicentie-gratis-hergebruik/v1.0'
+]
 
 
-def includeme(config):   # pragma: no cover
-    dataseturigenerator = UriPatternGenerator('https://id.erfgoed.net/datasets/thesauri/%s')
+def create_registry(request):
+    registry = Registry(instance_scope='threaded_thread')
+    dataseturigenerator = UriPatternGenerator(
+        'https://id.erfgoed.net/datasets/thesauri/%s'
+    )
 
-    TREES = SQLAlchemyProvider(
+    trees = SQLAlchemyProvider(
         {'id': 'TREES', 'conceptscheme_id': 1},
-        config.registry.dbmaker
+        request.db
     )
 
-    GEO = SQLAlchemyProvider(
+    geo = SQLAlchemyProvider(
         {'id': 'GEOGRAPHY', 'conceptscheme_id': 2},
-        config.registry.dbmaker
+        request.db
     )
 
-    STYLES = SQLAlchemyProvider(
+    styles = SQLAlchemyProvider(
         {
             'id': 'STYLES',
             'conceptscheme_id': 3,
             'dataset': {
                 'uri': dataseturigenerator.generate(id='stijlen_en_culturen'),
                 'publisher': ['https://id.erfgoed.net/actoren/501'],
-                'created': [date(2008,2,14)],
+                'created': [date(2008, 2, 14)],
                 'language': ['nl-BE'],
-                'license': [
-                    'https://creativecommons.org/licenses/by/4.0/',
-                    'http://data.vlaanderen.be/doc/licentie/modellicentie-gratis-hergebruik/v1.0'
-                ]
+                'license': LICENSES
             }
 
         },
-        config.registry.dbmaker,
-        uri_generator=UriPatternGenerator('https://id.erfgoed.net/thesauri/stijlen_en_culturen/%s')
+        request.db,
+        uri_generator=UriPatternGenerator(
+            'https://id.erfgoed.net/thesauri/stijlen_en_culturen/%s'
+        )
     )
 
-    MATERIALS = SQLAlchemyProvider(
+    materials = SQLAlchemyProvider(
         {
             'id': 'MATERIALS',
             'conceptscheme_id': 4,
             'dataset': {
                 'uri': dataseturigenerator.generate(id='materialen'),
                 'publisher': ['https://id.erfgoed.net/actoren/501'],
-                'created': [date(2011,3,16)],
+                'created': [date(2011, 3, 16)],
                 'language': ['nl-BE'],
-                'license': [
-                    'https://creativecommons.org/licenses/by/4.0/',
-                    'http://data.vlaanderen.be/doc/licentie/modellicentie-gratis-hergebruik/v1.0'
-                ]
+                'license': LICENSES
             }
         },
-        config.registry.dbmaker,
+        request.db,
         uri_generator=UriPatternGenerator('https://id.erfgoed.net/thesauri/materialen/%s')
     )
 
-    EVENTTYPES = SQLAlchemyProvider(
+    eventtypes = SQLAlchemyProvider(
         {
             'id': 'EVENTTYPE',
             'conceptscheme_id': 5,
             'dataset': {
                 'uri': dataseturigenerator.generate(id='gebeurtenistypes'),
                 'publisher': ['https://id.erfgoed.net/actoren/501'],
-                'created': [date(2010,8,13)],
+                'created': [date(2010, 8, 13)],
                 'language': ['nl-BE'],
-                'license': [
-                    'https://creativecommons.org/licenses/by/4.0/',
-                    'http://data.vlaanderen.be/doc/licentie/modellicentie-gratis-hergebruik/v1.0'
-                ]
+                'license': LICENSES
             }
         },
-        config.registry.dbmaker,
-        uri_generator=UriPatternGenerator('https://id.erfgoed.net/thesauri/gebeurtenistypes/%s')
+        request.db,
+        uri_generator=UriPatternGenerator(
+            'https://id.erfgoed.net/thesauri/gebeurtenistypes/%s'
+        )
     )
 
-    HERITAGETYPES = SQLAlchemyProvider(
+    heritagetypes = SQLAlchemyProvider(
         {
             'id': 'HERITAGETYPE',
             'conceptscheme_id': 6,
             'dataset': {
                 'uri': dataseturigenerator.generate(id='erfgoedtypes'),
                 'publisher': ['https://id.erfgoed.net/actoren/501'],
-                'created': [date(2008,2,14)],
+                'created': [date(2008, 2, 14)],
                 'language': ['nl-BE'],
-                'license': [
-                    'https://creativecommons.org/licenses/by/4.0/',
-                    'http://data.vlaanderen.be/doc/licentie/modellicentie-gratis-hergebruik/v1.0'
-                ]
+                'license': LICENSES
             }
         },
-        config.registry.dbmaker,
-        uri_generator=UriPatternGenerator('https://id.erfgoed.net/thesauri/erfgoedtypes/%s')
+        request.db,
+        uri_generator=UriPatternGenerator(
+            'https://id.erfgoed.net/thesauri/erfgoedtypes/%s'
+        )
     )
 
-    PERIODS = SQLAlchemyProvider(
+    periods = SQLAlchemyProvider(
         {
             'id': 'PERIOD',
             'conceptscheme_id': 7,
             'dataset': {
                 'uri': dataseturigenerator.generate(id='dateringen'),
                 'publisher': ['https://id.erfgoed.net/actoren/501'],
-                'created': [date(2008,2,14)],
+                'created': [date(2008, 2, 14)],
                 'language': ['nl-BE'],
-                'license': [
-                    'https://creativecommons.org/licenses/by/4.0/',
-                    'http://data.vlaanderen.be/doc/licentie/modellicentie-gratis-hergebruik/v1.0'
-                ]
+                'license': LICENSES
             }
         },
-        config.registry.dbmaker,
+        request.db,
         uri_generator=UriPatternGenerator('https://id.erfgoed.net/thesauri/dateringen/%s')
     )
 
-    SPECIES = SQLAlchemyProvider(
+    species = SQLAlchemyProvider(
         {
             'id': 'SPECIES',
             'conceptscheme_id': 8,
             'dataset': {
                 'uri': dataseturigenerator.generate(id='soorten'),
                 'publisher': ['https://id.erfgoed.net/actoren/501'],
-                'created': [date(2011,5,23)],
+                'created': [date(2011, 5, 23)],
                 'language': ['nl-BE', 'la'],
-                'license': [
-                    'https://creativecommons.org/licenses/by/4.0/',
-                    'http://data.vlaanderen.be/doc/licentie/modellicentie-gratis-hergebruik/v1.0'
-                ]
+                'license': LICENSES
             }
         },
-        config.registry.dbmaker,
+        request.db,
         uri_generator=UriPatternGenerator('https://id.erfgoed.net/thesauri/soorten/%s')
     )
 
-    # use 'subject': ['external'] for read only external providers (only available in REST service)
+    # use 'subject': ['external'] for read only external providers
+    # (only available in REST service)
 
     getty_session = CacheControl(requests.Session(), heuristic=ExpiresAfter(weeks=1))
 
-    AAT = AATProvider(
+    aat = AATProvider(
         {'id': 'AAT', 'subject': ['external']},
         session=getty_session
     )
 
-    TGN = TGNProvider(
+    tgn = TGNProvider(
         {'id': 'TGN', 'subject': ['external']},
         session=getty_session
     )
 
     eh_session = CacheControl(requests.Session(), heuristic=ExpiresAfter(weeks=1))
 
-    EH_PERIOD = HeritagedataProvider(
+    eh_period = HeritagedataProvider(
         {'id': 'EH_PERIOD', 'subject': ['external']},
         scheme_uri='http://purl.org/heritagedata/schemes/eh_period',
         session=eh_session
     )
 
-    EH_MONUMENT_TYPE = HeritagedataProvider(
+    eh_monument_type = HeritagedataProvider(
         {'id': 'EH_MONUMENT_TYPE', 'subject': ['external']},
         scheme_uri='http://purl.org/heritagedata/schemes/eh_tmt2',
         session=eh_session
     )
 
-    EH_MATERIALS = HeritagedataProvider(
+    eh_materials = HeritagedataProvider(
         {'id': 'EH_MATERIALS', 'subject': ['external']},
         scheme_uri='http://purl.org/heritagedata/schemes/eh_tbm',
         session=eh_session
     )
 
-    skosregis = config.get_skos_registry()
-    skosregis.register_provider(TREES)
-    skosregis.register_provider(GEO)
-    skosregis.register_provider(STYLES)
-    skosregis.register_provider(MATERIALS)
-    skosregis.register_provider(EVENTTYPES)
-    skosregis.register_provider(HERITAGETYPES)
-    skosregis.register_provider(PERIODS)
-    skosregis.register_provider(SPECIES)
-    skosregis.register_provider(AAT)
-    skosregis.register_provider(TGN)
-    skosregis.register_provider(EH_PERIOD)
-    skosregis.register_provider(EH_MONUMENT_TYPE)
-    skosregis.register_provider(EH_MATERIALS)
+    registry.register_provider(trees)
+    registry.register_provider(geo)
+    registry.register_provider(styles)
+    registry.register_provider(materials)
+    registry.register_provider(eventtypes)
+    registry.register_provider(heritagetypes)
+    registry.register_provider(periods)
+    registry.register_provider(species)
+    registry.register_provider(aat)
+    registry.register_provider(tgn)
+    registry.register_provider(eh_period)
+    registry.register_provider(eh_monument_type)
+    registry.register_provider(eh_materials)
+    return registry

--- a/atramhasis/views/exception_views.py
+++ b/atramhasis/views/exception_views.py
@@ -52,7 +52,7 @@ def protected(exc, request):
     """
     when a protected operation is called on a resource that is still referenced
     """
-    log.warn("'message': {0}, 'referenced_in': {1}".format(exc.value, exc.referenced_in))
+    log.warning("'message': {0}, 'referenced_in': {1}".format(exc.value, exc.referenced_in))
     request.response.status_int = 409
     return {'message': exc.value, 'referenced_in': exc.referenced_in}
 
@@ -72,7 +72,7 @@ def data_integrity(exc, request):
     """
     View invoked when IntegrityError was raised.
     """
-    log.warn(exc)
+    log.warning(exc)
     request.response.status_int = 409
     return {'message': 'this operation violates the data integrity and could not be executed '}
 

--- a/development.ini
+++ b/development.ini
@@ -21,6 +21,9 @@ jinja2.extensions =
     jinja2.ext.with_
 available_languages = en nl fr
 
+skosprovider.skosregistry_location = request
+skosprovider.skosregistry_factory = atramhasis.skos.create_registry
+
 # cache
 cache.tree.backend = dogpile.cache.memory
 cache.tree.arguments.cache_size = 5000
@@ -30,8 +33,8 @@ cache.list.backend = dogpile.cache.memory
 cache.list.arguments.cache_size = 5000
 cache.list.expiration_time = 7000
 
-sqlalchemy.url = sqlite:///%(here)s/atramhasis.sqlite
-#sqlalchemy.url = postgresql://atramhasis:atramhasis@localhost:5432/atramhasis
+#sqlalchemy.url = sqlite:///%(here)s/atramhasis.sqlite
+sqlalchemy.url = postgresql://postgres:postgres@localhost:5432/atramhasis
 
 atramhasis.session_factory.secret = itsaseekreet
 

--- a/development.ini
+++ b/development.ini
@@ -33,8 +33,8 @@ cache.list.backend = dogpile.cache.memory
 cache.list.arguments.cache_size = 5000
 cache.list.expiration_time = 7000
 
-#sqlalchemy.url = sqlite:///%(here)s/atramhasis.sqlite
-sqlalchemy.url = postgresql://postgres:postgres@localhost:5432/atramhasis
+sqlalchemy.url = sqlite:///%(here)s/atramhasis.sqlite
+# sqlalchemy.url = postgresql://postgres:postgres@localhost:5432/atramhasis
 
 atramhasis.session_factory.secret = itsaseekreet
 

--- a/production.ini
+++ b/production.ini
@@ -6,6 +6,9 @@
 [app:main]
 use = egg:atramhasis
 
+skosprovider.skosregistry_location = request
+skosprovider.skosregistry_factory = atramhasis.skos.create_registry
+
 pyramid.reload_templates = false
 pyramid.debug_authorization = false
 pyramid.debug_notfound = false

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,13 +4,13 @@ pyramid-tm==2.2.1
 pyramid_rewrite==0.2
 
 #skosprovider==0.7.0
--e git+https://github.com/koenedaele/skosprovider.git@DEV_0.7.0#egg=skosprovider
+-e git+https://github.com/koenedaele/skosprovider.git@develop#egg=skosprovider
 #skosprovider_sqlalchemy==0.6.0
 -e git+https://github.com/koenedaele/skosprovider_sqlalchemy.git@DEV_0.6.0#egg=skosprovider_sqlalchemy
 #pyramid_skosprovider==0.9.0
 -e git+https://github.com/koenedaele/pyramid_skosprovider.git@DEV_0.9#egg=pyramid_skosprovider
-#skosprovider_rdf==0.7.0
--e git+https://github.com/OnroerendErfgoed/skosprovider_rdf.git@DEV_0.7.0#egg=skosprovider_rdf
+skosprovider_rdf==0.7.0
+#-e git+https://github.com/OnroerendErfgoed/skosprovider_rdf.git@develop#egg=skosprovider_rdf
 #skosprovider_getty==0.5.2
 -e git+https://github.com/OnroerendErfgoed/skosprovider_getty.git@DEV_0.5.0#egg=skosprovider_getty
 skosprovider_heritagedata==0.3.1

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -17,12 +17,18 @@ from sqlalchemy.exc import OperationalError
 from sqlalchemy.exc import ProgrammingError
 from sqlalchemy.orm import sessionmaker
 
+from atramhasis.cache import list_region
+from atramhasis.cache import tree_region
 from fixtures import data
 from fixtures import materials as material_data
 
 TEST_DIR = os.path.dirname(__file__)
 SETTINGS = get_appsettings(os.path.join(TEST_DIR, '..', 'tests', 'conf_test.ini'))
 db_setup = False
+
+# No test should want caching
+tree_region.configure('dogpile.cache.null', replace_existing_backend=True)
+list_region.configure('dogpile.cache.null', replace_existing_backend=True)
 
 
 def get_alembic_config():

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,1 +1,172 @@
 # -*- coding: utf-8 -*-
+import contextlib
+import os
+import unittest
+
+from alembic import command
+from alembic.config import Config
+from pyramid.paster import get_appsettings
+from skosprovider.providers import DictionaryProvider
+from skosprovider.registry import Registry
+from skosprovider.skos import ConceptScheme
+from skosprovider.uri import UriPatternGenerator
+from skosprovider_sqlalchemy.providers import SQLAlchemyProvider
+from skosprovider_sqlalchemy.utils import import_provider
+from sqlalchemy import engine_from_config
+from sqlalchemy.exc import OperationalError
+from sqlalchemy.exc import ProgrammingError
+from sqlalchemy.orm import sessionmaker
+
+from fixtures import data
+from fixtures import materials as material_data
+
+TEST_DIR = os.path.dirname(__file__)
+SETTINGS = get_appsettings(os.path.join(TEST_DIR, '..', 'tests', 'conf_test.ini'))
+db_setup = False
+
+
+def get_alembic_config():
+    alembic_config = Config(os.path.join(TEST_DIR, '..', 'alembic.ini'))
+    alembic_config.set_main_option(
+        "script_location",
+        os.path.join(TEST_DIR, '..', 'atramhasis', 'alembic')
+    )
+    alembic_config.set_main_option(
+        "ini_location",
+        os.path.join(TEST_DIR, '..', 'tests', 'conf_test.ini')
+    )
+    return alembic_config
+
+
+ALEMBIC_CONFIG = get_alembic_config()
+
+
+def setup_db():
+    global db_setup
+    if not db_setup:
+        engine = engine_from_config(SETTINGS, prefix='sqlalchemy.')
+        if engine.name == 'sqlite':
+            # Can't alembic downgrade sqlite because it can't do
+            # ALTER TABLE X DROP COLUMN
+            os.remove(os.path.join(TEST_DIR, engine.url.database))
+        elif engine.name == 'postgresql':
+            try:
+                engine.execute("DELETE FROM concept_note")
+                engine.execute("DELETE FROM note")
+                engine.execute("DELETE FROM concept_label")
+                engine.execute("DELETE FROM label")
+                command.downgrade(ALEMBIC_CONFIG, 'base')
+            except ProgrammingError:
+                """The tables may not exist if it's first time."""
+            command.downgrade(ALEMBIC_CONFIG, 'base')
+
+        engine.dispose()
+        command.upgrade(ALEMBIC_CONFIG, 'head')
+
+        from fixtures.data import trees
+        from skosprovider_sqlalchemy.models import ConceptScheme
+        with db_session() as session:
+            import_provider(trees,
+                            ConceptScheme(id=1, uri='urn:x-skosprovider:trees'),
+                            session)
+            import_provider(material_data.materials,
+                            ConceptScheme(id=4, uri='urn:x-vioe:materials'),
+                            session)
+            import_provider(data.geo,
+                            ConceptScheme(id=2, uri='urn:x-vioe:geography'),
+                            session)
+            session.add(ConceptScheme(id=3, uri='urn:x-vioe:styles'))
+            for scheme_id in (5, 6, 7, 8):
+                session.add(
+                    ConceptScheme(id=scheme_id, uri='urn:dummy-{}'.format(scheme_id))
+                )
+        db_setup = True
+
+
+class DbTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        super(DbTest, cls).setUpClass()
+        cls.engine = engine_from_config(SETTINGS, prefix='sqlalchemy.')
+        cls.connection = cls.engine.connect()
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.connection.close()
+        cls.engine.dispose()
+        super(DbTest, cls).tearDownClass()
+
+    def setUp(self):
+        super(DbTest, self).setUp()
+        self.transaction = self.connection.begin()
+        self.session = sessionmaker(bind=self.connection)()
+
+    def tearDown(self):
+        self.session.close()
+        self.transaction.rollback()
+
+    def insert(self, db_object):
+        self.session.add(db_object)
+        self.session.flush()
+        self.session.refresh(db_object)
+
+    def update(self, db_object):
+        self.session.merge(db_object)
+        self.session.flush()
+        self.session.refresh(db_object)
+
+
+@contextlib.contextmanager
+def db_session():
+    engine = engine_from_config(SETTINGS, prefix='sqlalchemy.')
+    session_maker = sessionmaker(bind=engine)
+    session = session_maker()
+    try:
+        yield session
+        session.commit()
+    except Exception:
+        session.rollback()
+        raise
+    finally:
+        session.close()
+
+
+def create_registry(request):
+    registry = Registry(instance_scope='threaded_thread')
+    trees = SQLAlchemyProvider(
+        {'id': 'TREES', 'conceptscheme_id': 1},
+        request.db
+    )
+
+    geo = SQLAlchemyProvider(
+        {'id': 'GEOGRAPHY', 'conceptscheme_id': 2},
+        request.db,
+        uri_generator=UriPatternGenerator('urn:x-vioe:geography:%s')
+    )
+
+    styles = SQLAlchemyProvider(
+        {'id': 'STYLES', 'conceptscheme_id': 3},
+        request.db
+    )
+
+    materials = SQLAlchemyProvider(
+        {'id': 'MATERIALS', 'conceptscheme_id': 4},
+        request.db,
+        uri_generator=UriPatternGenerator('urn:x-vioe:materials:%s')
+    )
+    test = DictionaryProvider(
+        {
+            'id': 'TEST',
+            'default_language': 'nl',
+            'subject': ['biology']
+        },
+        [data.larch, data.chestnut, data.species],
+        concept_scheme=ConceptScheme('http://id.trees.org')
+    )
+
+    registry.register_provider(trees)
+    registry.register_provider(geo)
+    registry.register_provider(styles)
+    registry.register_provider(materials)
+    registry.register_provider(test)
+    return registry

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -63,7 +63,7 @@ def _reset_db():
         # Can't alembic downgrade sqlite because it can't do
         # ALTER TABLE X DROP COLUMN
         try:
-            os.remove(os.path.join(TEST_DIR, engine.url.database))
+            os.remove(engine.url.database)
         except OSError:
             pass
     elif engine.name == 'postgresql':

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -51,26 +51,32 @@ ALEMBIC_CONFIG = get_alembic_config()
 def setup_db(guarantee_empty=False):
     global db_setup, db_filled
     if not db_setup or (guarantee_empty and db_filled):
-        engine = engine_from_config(SETTINGS, prefix='sqlalchemy.')
-        if engine.name == 'sqlite':
-            # Can't alembic downgrade sqlite because it can't do
-            # ALTER TABLE X DROP COLUMN
-            os.remove(os.path.join(TEST_DIR, engine.url.database))
-        elif engine.name == 'postgresql':
-            try:
-                engine.execute("DELETE FROM concept_note")
-                engine.execute("DELETE FROM note")
-                engine.execute("DELETE FROM concept_label")
-                engine.execute("DELETE FROM label")
-                command.downgrade(ALEMBIC_CONFIG, 'base')
-            except ProgrammingError:
-                """The tables may not exist if it's first time."""
-            command.downgrade(ALEMBIC_CONFIG, 'base')
-
-        engine.dispose()
+        _reset_db()
         command.upgrade(ALEMBIC_CONFIG, 'head')
         db_setup = True
         db_filled = False
+
+
+def _reset_db():
+    engine = engine_from_config(SETTINGS, prefix='sqlalchemy.')
+    if engine.name == 'sqlite':
+        # Can't alembic downgrade sqlite because it can't do
+        # ALTER TABLE X DROP COLUMN
+        try:
+            os.remove(os.path.join(TEST_DIR, engine.url.database))
+        except OSError:
+            pass
+    elif engine.name == 'postgresql':
+        try:
+            engine.execute("DELETE FROM concept_note")
+            engine.execute("DELETE FROM note")
+            engine.execute("DELETE FROM concept_label")
+            engine.execute("DELETE FROM label")
+            command.downgrade(ALEMBIC_CONFIG, 'base')
+        except ProgrammingError:
+            """The tables may not exist if it's first time."""
+        command.downgrade(ALEMBIC_CONFIG, 'base')
+    engine.dispose()
 
 
 def fill_db():

--- a/tests/conf_test.ini
+++ b/tests/conf_test.ini
@@ -21,9 +21,14 @@ jinja2.extensions =
     jinja2.ext.do
     jinja2.ext.with_
 available_languages = en nl it
-sqlalchemy.url = sqlite:///:memory:
+sqlalchemy.url = sqlite:///test.db
+# sqlalchemy.url = postgresql://postgres:postgres@localhost:5432/atramhasis_test
+
 
 atramhasis.session_factory.secret = testing123
+
+skosprovider.skosregistry_location = request
+skosprovider.skosregistry_factory = tests.create_registry
 
 # cache
 cache.tree.backend = dogpile.cache.memory

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,44 +1,22 @@
 import os
 import random
 import shutil
-import unittest
 
 from pyramid.paster import get_appsettings
-from skosprovider_sqlalchemy.utils import import_provider
-from sqlalchemy import engine_from_config
-from sqlalchemy.orm import sessionmaker
-import transaction
-from zope.sqlalchemy import ZopeTransactionExtension
-from skosprovider_sqlalchemy.models import Base, ConceptScheme
 
 from atramhasis import main
-from fixtures.data import trees, geo
-from fixtures.materials import materials
-from fixtures.styles_and_cultures import styles_and_cultures
-
+from tests import DbTest
+from tests import setup_db
 
 here = os.path.dirname(__file__)
 settings = get_appsettings(os.path.join(here, '../', 'tests/conf_test.ini'))
 
 
-class TestConfig(unittest.TestCase):
-    def setUp(self):
-        settings['sqlalchemy.url'] = 'sqlite:///%s/dbtest.sqlite' % here
-        self.engine = engine_from_config(settings, prefix='sqlalchemy.')
-        Base.metadata.drop_all(self.engine)
-        Base.metadata.create_all(self.engine)
+def setUpModule():
+    setup_db()
 
-        session_maker = sessionmaker(
-            bind=self.engine,
-            extension=ZopeTransactionExtension()
-        )
 
-        with transaction.manager:
-            local_session = session_maker()
-            import_provider(trees, ConceptScheme(id=1, uri='urn:x-skosprovider:trees'), local_session)
-            import_provider(materials, ConceptScheme(id=4, uri='urn:x-vioe:materials'), local_session)
-            import_provider(geo, ConceptScheme(id=2, uri='urn:x-vioe:geo'), local_session)
-            import_provider(styles_and_cultures, ConceptScheme(id=3, uri='urn:x-vioe:styles'), local_session)
+class TestConfig(DbTest):
 
     def test_config(self):
         app = main({}, **settings)

--- a/tests/test_datamanagers.py
+++ b/tests/test_datamanagers.py
@@ -16,6 +16,7 @@ from atramhasis.data.datamanagers import SkosManager
 from atramhasis.data.models import ConceptVisitLog
 from atramhasis.data.models import ConceptschemeCounts
 from tests import DbTest
+from tests import fill_db
 from tests import setup_db
 
 try:
@@ -26,6 +27,7 @@ except ImportError:
 
 def setUpModule():
     setup_db()
+    fill_db()
 
 
 class ConceptSchemeManagerTest(DbTest):

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -21,6 +21,7 @@ from fixtures.data import larch
 from fixtures.data import species
 from tests import DbTest
 from tests import SETTINGS
+from tests import fill_db
 from tests import setup_db
 
 try:
@@ -31,6 +32,7 @@ except ImportError:
 
 def setUpModule():
     setup_db()
+    fill_db()
 
 
 logging.basicConfig(level=logging.DEBUG, stream=sys.stdout)

--- a/tests/test_rdf.py
+++ b/tests/test_rdf.py
@@ -91,7 +91,7 @@ class MetadatasetTests(unittest.TestCase):
         uri = URIRef('http://test.atramhasis.org/void.ttl#emptyset')
         g.add((uri, RDF.type, VOID.Dataset))
         g = _add_metadataset(g, uri, metadataset)
-        self.assertEquals(1, len(g))
+        assert len(g) == 1
 
     def test_add_metadataset(self):
         metadataset = {
@@ -107,7 +107,7 @@ class MetadatasetTests(unittest.TestCase):
         uri = URIRef('http://id.python.org/datasets/different_types_of_trees')
         g.add((uri, RDF.type, VOID.Dataset))
         g = _add_metadataset(g, uri, metadataset)
-        self.assertEquals(8, len(g))
+        assert len(g) == 8
         self.assertIn((uri, DCTERMS.language, Literal('nl')), g)
         self.assertIn((uri, DCTERMS.language, Literal('fr')), g)
         self.assertIn((uri, DCTERMS.language, Literal('en')), g)

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -572,11 +572,6 @@ class TestListViews(unittest.TestCase):
         self.config = testing.setUp()
         self.request = testing.DummyRequest()
         self.request.data_managers = list_db(self.request)
-        if not list_region.is_configured:
-            list_region.configure('dogpile.cache.memory')
-
-    def tearDown(self):
-        testing.tearDown()
 
     def test_get_list(self):
         request = self.request
@@ -590,4 +585,7 @@ class TestListViews(unittest.TestCase):
         atramhasis_list_view = AtramhasisListView(request)
         labellist = atramhasis_list_view.labeltype_list_view()
         self.assertIsNotNone(labellist)
-        self.assertIn({'key': 'prefLabel', 'label': u'prefLabel'}, labellist)
+        self.assertIn(
+            {'key': 'prefLabel', 'label': u'prefLabel'},
+            labellist
+        )


### PR DESCRIPTION
Er zit wel wat meer in dan origineel in het ticket. Maar met minder ging het volgens mij moeilijk.

- requests hebben nu een `db` property. Dat is de database session, 1 per request. Wordt gebruikt voor zowel de datamanagers zoals vroeger als ook de sqlalchemyproviders per request.
- alembic voor updates in skosprovider
- testen gebruiken niet langer een in-memory sqlite maar file-based. Zo kan ik ook alembic erbij gebruiken en is die ineens mee getest. Door de algemene test changes qua setup en teardown van de classes en testen is de (functionele) test duurtijd gezakt van 49sec met in-memory DB naar 5 sec met sqlite file. Dus veel zal dat niet geven.
- `skos/__init__.py` aangepast aan nieuw manier van opbouwen Registry.
- development, productie (hoewel die vrij leeg is?) en test `.ini` changes voor de nieuwe registry.
- Nieuwe `DbTest` class die iedere test die een database wil gebruiken zou moeten gebruiken. Elke test heeft zijn eigen `self.session` binnen een transaction, rollback na elke test.

~~Ik heb de niet-functionele testen nog niet bekeken.~~
