### PR TITLE
Allow editing infer_concept_relations for collections.

### DIFF
--- a/atramhasis/mappers.py
+++ b/atramhasis/mappers.py
@@ -173,6 +173,8 @@ def map_concept(concept, concept_json, skos_manager):
                 except NoResultFound:
                     broader_concept = Concept(concept_id=broader['id'], conceptscheme_id=concept.conceptscheme_id)
                 concept.broader_concepts.add(broader_concept)
+            if 'infer_concept_relations' in concept_json:
+                concept.infer_concept_relations = concept_json['infer_concept_relations']
     return concept
 
 

--- a/atramhasis/renderers.py
+++ b/atramhasis/renderers.py
@@ -136,7 +136,8 @@ def collection_adapter(obj, request):
         'sources': obj.sources,
         'members': [map_relation(c, language) for c in obj.members],
         'member_of': [map_relation(c, language) for c in obj.member_of],
-        'superordinates': [map_relation(c, language) for c in obj.broader_concepts]
+        'superordinates': [map_relation(c, language) for c in obj.broader_concepts],
+        'infer_concept_relations': obj.infer_concept_relations
     }
 
 

--- a/atramhasis/utils.py
+++ b/atramhasis/utils.py
@@ -34,7 +34,8 @@ def from_thing(thing):
             ],
             members=[member.concept_id for member in thing.members] if hasattr(thing, 'members') else [],
             member_of=[c.concept_id for c in thing.member_of],
-            superordinates=[broader_concept.concept_id for broader_concept in thing.broader_concepts]
+            superordinates=[broader_concept.concept_id for broader_concept in thing.broader_concepts],
+            infer_concept_relations=thing.infer_concept_relations
         )
     else:
         matches = {}

--- a/atramhasis/validators.py
+++ b/atramhasis/validators.py
@@ -120,6 +120,10 @@ class Concept(colander.MappingSchema):
     subordinate_arrays = Concepts(missing=[])
     superordinates = Concepts(missing=[])
     matches = Matches(missing={})
+    infer_concept_relations = colander.SchemaNode(
+        colander.Boolean(),
+        missing=colander.drop
+    )
 
 
 class ConceptScheme(colander.MappingSchema):
@@ -231,6 +235,10 @@ def concept_schema_validator(node, cstruct):
         superordinates_only_in_concept_rule(errors, node['superordinates'], concept_type, superordinates)
         superordinates_type_rule(errors, node['superordinates'], skos_manager, conceptscheme_id, superordinates)
         superordinates_hierarchy_rule(errors, node['superordinates'], skos_manager, conceptscheme_id, cstruct)
+
+    if cstruct['type'] == 'concept' and 'infer_concept_relations' in cstruct:
+        msg = "'infer_concept_relations' can only be set for collections."
+        errors.append(colander.Invalid(node['infer_concept_relations'], msg=msg))
 
     if len(errors) > 0:
         raise ValidationError(

--- a/atramhasis/views/crud.py
+++ b/atramhasis/views/crud.py
@@ -206,9 +206,10 @@ class AtramhasisCrud(object):
             concept = self.skos_manager.get_thing(c_id, self.provider.conceptscheme_id)
         except NoResultFound:
             raise ConceptNotFoundException(c_id)
+        result = from_thing(concept)
         self.skos_manager.delete_thing(concept)
 
         invalidate_scheme_cache(self.scheme_id)
 
         self.request.response.status = '200'
-        return from_thing(concept)
+        return result

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -108,7 +108,8 @@ json_collection_value = {
         "note": "een notitie",
         "type": "note",
         "language": "nl"
-    }]
+    }],
+    'infer_concept_relations': True
 }
 
 TEST = DictionaryProvider(
@@ -320,6 +321,7 @@ class RestFunctionalTests(FunctionalTests):
 
     def test_edit_collection(self):
         json_collection_value['members'] = [{"id": 7}, {"id": 8}]
+        json_collection_value['infer_concept_relations'] = False
         res = self.testapp.put_json('/conceptschemes/GEOGRAPHY/c/333', headers=self._get_default_headers(),
                                     params=json_collection_value)
         self.assertEqual('200 OK', res.status)
@@ -327,6 +329,7 @@ class RestFunctionalTests(FunctionalTests):
         self.assertIsNotNone(res.json['id'])
         self.assertEqual(res.json['type'], 'collection')
         self.assertEqual(2, len(res.json['members']))
+        self.assertFalse(res.json['infer_concept_relations'])
 
     def test_delete_collection(self):
         res = self.testapp.delete('/conceptschemes/GEOGRAPHY/c/333', headers=self._get_default_headers())

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -311,6 +311,20 @@ class TestValidation(unittest.TestCase):
         self.assertTrue(isinstance(error, ValidationError))
         self.assertIn({'narrower': 'A narrower, broader or related concept'
                                    ' should always be a concept, not a collection'}, error.errors)
+    
+    def test_infer_concept_relations(self):
+        self.json_concept['infer_concept_relations'] = True
+        with self.assertRaises(ValidationError) as e:
+            self.concept_schema.deserialize(self.json_concept)
+        self.assertIn(
+            {
+                'infer_concept_relations': "'infer_concept_relations' can only "
+                                           "be set for collections."
+            },
+            e.exception.errors
+        )
+        self.json_collection['infer_concept_relations'] = True
+        self.concept_schema.deserialize(self.json_collection)
 
     def test_collection_with_narrower(self):
         # Collections can not have narrower relations


### PR DESCRIPTION
Dit heeft https://github.com/koenedaele/pyramid_skosprovider/issues/72 nodig.