### PR TITLE
Update cachecontrol to 0.13.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -41,4 +41,4 @@ bleach==5.0.1
 
 # requests
 requests==2.31.0
-cachecontrol==0.12.11
+cachecontrol==0.13.1


### PR DESCRIPTION
This version of cachecontrol uses an version of urllib3 that is incompatible with requests 2.30+, see https://github.com/psf/cachecontrol/issues/292

It results in the following error: `AttributeError: 'HTTPResponse' object has no attribute 'strict'`

This version update should solve this issue, but in case it doesn't, you could also fix `urllib3==1.26.15`