### PR TITLE
Feature/876 cookiecutters compile requirements

### DIFF
--- a/docs/source/development.rst
+++ b/docs/source/development.rst
@@ -135,8 +135,6 @@ Afterward, run pip-compile to generate the requirements files.
     $ echo "requirements.txt generated"
     $ pip-compile -q --strip-extras --no-header --resolver=backtracking --all-extras --no-emit-options --no-emit-trusted-host --no-emit-find-links -o requirements-dev.txt pyproject.toml;
     $ echo "requirements-dev.txt generated"
-    $ pip-compile -q --strip-extras --no-header --resolver=backtracking --no-emit-options --no-emit-trusted-host --no-emit-find-links -o requirements-ci.txt pyproject.toml;
-    $ echo "requirements-ci.txt generated"
 
 Admin development
 =================

--- a/docs/source/development.rst
+++ b/docs/source/development.rst
@@ -129,11 +129,11 @@ The dependencies are defined within pyproject.toml. There, you can add, modify, 
 Afterward, run pip-compile to generate the requirements files.
 
 .. code-block:: bash
-
     # Update pyproject.toml and run pip-compile as follows:
-    $ pip-compile -q --strip-extras --no-header --resolver=backtracking --no-emit-options --no-emit-trusted-host --no-emit-find-links -o requirements.txt pyproject.toml;
+    $ PIP_COMPILE_ARGS="-v --strip-extras --no-header --resolver=backtracking --no-emit-options --no-emit-find-links";
+    $ pip-compile $PIP_COMPILE_ARGS;
     $ echo "requirements.txt generated"
-    $ pip-compile -q --strip-extras --no-header --resolver=backtracking --all-extras --no-emit-options --no-emit-trusted-host --no-emit-find-links -o requirements-dev.txt pyproject.toml;
+    $ pip-compile $PIP_COMPILE_ARGS --all-extras -o requirements-dev.txt;
     $ echo "requirements-dev.txt generated"
 
 Admin development

--- a/docs/source/development.rst
+++ b/docs/source/development.rst
@@ -123,6 +123,21 @@ production environment.
     $ pserve --reload development.ini
 
 
+Update requirements files
+=========================
+The dependencies are defined within pyproject.toml. There, you can add, modify, or remove libraries.
+Afterward, run pip-compile to generate the requirements files.
+
+.. code-block:: bash
+
+    # Update pyproject.toml and run pip-compile as follows:
+    $ pip-compile -q --strip-extras --no-header --resolver=backtracking --no-emit-options --no-emit-trusted-host --no-emit-find-links -o requirements.txt pyproject.toml;
+    $ echo "requirements.txt generated"
+    $ pip-compile -q --strip-extras --no-header --resolver=backtracking --all-extras --no-emit-options --no-emit-trusted-host --no-emit-find-links -o requirements-dev.txt pyproject.toml;
+    $ echo "requirements-dev.txt generated"
+    $ pip-compile -q --strip-extras --no-header --resolver=backtracking --no-emit-options --no-emit-trusted-host --no-emit-find-links -o requirements-ci.txt pyproject.toml;
+    $ echo "requirements-ci.txt generated"
+
 Admin development
 =================
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -38,8 +38,6 @@ docutils==0.19
     # via sphinx
 dogpile-cache==1.3.3
     # via atramhasis (pyproject.toml)
-exceptiongroup==1.2.1
-    # via pytest
 flake8==4.0.1
     # via atramhasis (pyproject.toml)
 frozendict==2.4.4
@@ -217,12 +215,6 @@ rpds-py==0.18.1
     # via
     #   jsonschema
     #   referencing
-setuptools==70.0.0
-    # via
-    #   pyramid
-    #   zope-deprecation
-    #   zope-interface
-    #   zope-sqlalchemy
 six==1.16.0
     # via
     #   bleach
@@ -268,18 +260,14 @@ sphinxcontrib-serializinghtml==1.1.10
     # via sphinx
 sqlalchemy==2.0.30
     # via
-    #   atramhasis (pyproject.toml)
     #   alembic
+    #   atramhasis (pyproject.toml)
     #   skosprovider-sqlalchemy
     #   zope-sqlalchemy
 stevedore==5.2.0
     # via dogpile-cache
 testfixtures==7.2.2
     # via atramhasis (pyproject.toml)
-tomli==2.0.1
-    # via
-    #   coverage
-    #   pytest
 transaction==4.0
     # via
     #   atramhasis (pyproject.toml)
@@ -292,7 +280,6 @@ translationstring==1.4
 typing-extensions==4.12.2
     # via
     #   alembic
-    #   dogpile-cache
     #   sqlalchemy
 urllib3==2.2.2
     # via requests
@@ -325,3 +312,6 @@ zope-interface==6.4.post2
     #   zope-sqlalchemy
 zope-sqlalchemy==3.1
     # via atramhasis (pyproject.toml)
+
+# The following packages are considered to be unsafe in a requirements file:
+# setuptools

--- a/requirements.txt
+++ b/requirements.txt
@@ -152,12 +152,6 @@ rpds-py==0.18.1
     # via
     #   jsonschema
     #   referencing
-setuptools==70.0.0
-    # via
-    #   pyramid
-    #   zope-deprecation
-    #   zope-interface
-    #   zope-sqlalchemy
 six==1.16.0
     # via
     #   bleach
@@ -180,8 +174,8 @@ skosprovider-sqlalchemy==2.1.1
     # via atramhasis (pyproject.toml)
 sqlalchemy==2.0.30
     # via
-    #   atramhasis (pyproject.toml)
     #   alembic
+    #   atramhasis (pyproject.toml)
     #   skosprovider-sqlalchemy
     #   zope-sqlalchemy
 stevedore==5.2.0
@@ -198,7 +192,6 @@ translationstring==1.4
 typing-extensions==4.12.2
     # via
     #   alembic
-    #   dogpile-cache
     #   sqlalchemy
 urllib3==2.2.2
     # via requests
@@ -223,3 +216,6 @@ zope-interface==6.4.post2
     #   zope-sqlalchemy
 zope-sqlalchemy==3.1
     # via atramhasis (pyproject.toml)
+
+# The following packages are considered to be unsafe in a requirements file:
+# setuptools


### PR DESCRIPTION
This PR builds upon #854, which addresses the removal of setuptools and #876, where I noticed the requirements files were not up to date. It updates the documentation on how to generate requirements files and also ensures that the requirements files are up-to-date after running pip-compile.