### PR TITLE
Remove wrong commandline from documentation. #882

### DIFF
--- a/docs/source/customisation.rst
+++ b/docs/source/customisation.rst
@@ -29,7 +29,7 @@ Usage
 
     .. code-block:: bash
 
-        # create a new virtual environment for the project, fe python -m venv $HOME/.virtualenvs/my_atramhasis
+        # create a new virtual environment for the project, set VENV_PATH to the desired location
         $ VENV_PATH=$HOME/Envs
         $ python -m venv $VENV_PATH/my_atramhasis
         $ . $VENV_PATH/my_atramhasis/bin/activate

--- a/docs/source/customisation.rst
+++ b/docs/source/customisation.rst
@@ -29,8 +29,9 @@ Usage
 
     .. code-block:: bash
 
-        # create a new virtual environment for the project, set VENV_PATH to the desired location
+        # set VENV_PATH to the desired location for your new virtual environment
         $ VENV_PATH=$HOME/Envs
+        # create a new virtual environment for the project
         $ python -m venv $VENV_PATH/my_atramhasis
         $ . $VENV_PATH/my_atramhasis/bin/activate
         # Make sure pip and pip-tools are up to date

--- a/docs/source/demo.rst
+++ b/docs/source/demo.rst
@@ -17,8 +17,9 @@ This can be done through the `cookiecutter` package.
 
 .. code-block:: bash
 
-    # create a new virtual environment for the project, set VENV_PATH to the desired location
+    # set VENV_PATH to the desired location for your new virtual environment
     $ VENV_PATH=$HOME/Envs
+    # create a new virtual environment for the project
     $ python -m venv $VENV_PATH/my_atramhasis
     $ . $VENV_PATH/my_atramhasis/bin/activate
     # Make sure pip and pip-tools are up to date

--- a/docs/source/demo.rst
+++ b/docs/source/demo.rst
@@ -17,12 +17,12 @@ This can be done through the `cookiecutter` package.
 
 .. code-block:: bash
 
-    # create a new virtual environment for the project, fe python -m venv $HOME/.virtualenvs/my_atramhasis
+    # create a new virtual environment for the project, set VENV_PATH to the desired location
     $ VENV_PATH=$HOME/Envs
     $ python -m venv $VENV_PATH/my_atramhasis
     $ . $VENV_PATH/my_atramhasis/bin/activate
     # Make sure pip and pip-tools are up to date
-    $ pip install --upgrade pip pip-tools
+    $ pip install --upgrade pip
     $ pip install --upgrade cookiecutter
 
 2.  Use cookiecutter to generate an demo project
@@ -70,7 +70,6 @@ functionality:
 
 .. code-block:: bash
 
-    $ cd ../..
     # start server
     $ pserve development.ini
 


### PR DESCRIPTION
#882 and a little extra:
- When creating a demo, pip-tools is not necessary.
If you want to create your own project from the scaffold, pip-tools can be useful for using pip-sync (as described in step 3 of the [customization guide](https://atramhasis.readthedocs.io/en/latest/customisation.html#creating-your-own-project)). Therefore, you do need pip-tools in this case.
- Improved comment about choosing a desired path to install your virtualenv

