### PR TITLE
Run scrutinizer on python 3.12

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -9,6 +9,8 @@ checks:
 
 
 build:
+  environment:
+      python: 3.12
   nodes:
     analysis:
       tests:


### PR DESCRIPTION
This will fix the failed setups. Scrutinizer is using python 3.7.2 by default. Some libraries are not available for older python versions.