### PR TITLE
Bugfix/883 enable conceptscheme buttons in admin menu

### DIFF
--- a/atramhasis/static/admin/src/app/ui/AppUi.js
+++ b/atramhasis/static/admin/src/app/ui/AppUi.js
@@ -174,10 +174,6 @@ define([
     },
     refresh_conceptschemes: function () {
       console.debug('AppUi::refresh_conceptschemes');
-      // this.conceptSchemeController.loadConceptSchemeStores();
-      // this._searchPane.conceptSchemeList = this.conceptSchemeController.conceptSchemeList;
-      // this._searchPane._fillConceptSchemeSelect(this.conceptSchemeController.conceptSchemeList);
-      // this._searchPane._initSelectedConceptSchemeAdmin();
       var message = 'Please manually reload the page to see the changes in the main menu.';
       topic.publish('dGrowl', message, {
         'title': 'New Provider added',

--- a/atramhasis/static/admin/src/app/ui/AppUi.js
+++ b/atramhasis/static/admin/src/app/ui/AppUi.js
@@ -172,6 +172,19 @@ define([
 
       router.startup('#');
     },
+    refresh_conceptschemes: function () {
+      console.debug('AppUi::refresh_conceptschemes');
+      // this.conceptSchemeController.loadConceptSchemeStores();
+      // this._searchPane.conceptSchemeList = this.conceptSchemeController.conceptSchemeList;
+      // this._searchPane._fillConceptSchemeSelect(this.conceptSchemeController.conceptSchemeList);
+      // this._searchPane._initSelectedConceptSchemeAdmin();
+      var message = 'Please manually reload the page to see the changes in the main menu.';
+      topic.publish('dGrowl', message, {
+        'title': 'New Provider added',
+        'sticky': false,
+        'channel': 'info'
+      });
+    },
 
     /**
      * Hide the 'Loading'-overlay.

--- a/atramhasis/static/admin/src/app/ui/dialogs/ManageProvidersDialog.js
+++ b/atramhasis/static/admin/src/app/ui/dialogs/ManageProvidersDialog.js
@@ -350,6 +350,7 @@ define([
             'channel': 'info'
           });
           this._reset(true);
+          this.parentNode.refresh_conceptschemes();
         }),
         lang.hitch(this, function (error) {
           var message = this._parseError(error);

--- a/atramhasis/static/admin/src/app/ui/widgets/SearchPane.js
+++ b/atramhasis/static/admin/src/app/ui/widgets/SearchPane.js
@@ -67,12 +67,7 @@ define([
       if (this.appUi.canCreateProviders) {
         domAttr.set(this.manageProvidersButton, 'disabled', false);
       }
-      if (this.conceptSchemeList.length > 0) {
-        domAttr.set(this.addConceptButton, 'disabled', false);
-        domAttr.set(this.importConceptButton, 'disabled', false);
-        domAttr.set(this.editSchemeButton, 'disabled', false);
-        this._search();
-      }
+      this._initSelectedConceptSchemeAdmin();
     },
 
     init: function (scheme, store) {
@@ -172,6 +167,15 @@ define([
           this._search();
         }))
       );
+    },
+
+    _initSelectedConceptSchemeAdmin: function () {
+      if (this.conceptSchemeList.length > 0) {
+        domAttr.set(this.addConceptButton, 'disabled', false);
+        domAttr.set(this.importConceptButton, 'disabled', false);
+        domAttr.set(this.editSchemeButton, 'disabled', false);
+        this._search();
+      }
     },
 
     _createContextMenu: function () {

--- a/atramhasis/static/admin/src/app/ui/widgets/SearchPane.js
+++ b/atramhasis/static/admin/src/app/ui/widgets/SearchPane.js
@@ -67,6 +67,12 @@ define([
       if (this.appUi.canCreateProviders) {
         domAttr.set(this.manageProvidersButton, 'disabled', false);
       }
+      if (this.conceptSchemeList.length > 0) {
+        domAttr.set(this.addConceptButton, 'disabled', false);
+        domAttr.set(this.importConceptButton, 'disabled', false);
+        domAttr.set(this.editSchemeButton, 'disabled', false);
+        this._search();
+      }
     },
 
     init: function (scheme, store) {
@@ -163,10 +169,6 @@ define([
           this.emit('scheme.changed', {
             schemeId: this.conceptSchemeSelect.value
           });
-          // activate buttons for add and import, edit scheme
-          domAttr.set(this.addConceptButton, 'disabled', false);
-          domAttr.set(this.importConceptButton, 'disabled', false);
-          domAttr.set(this.editSchemeButton, 'disabled', false);
           this._search();
         }))
       );

--- a/atramhasis/static/admin/src/app/ui/widgets/templates/SearchPane.html
+++ b/atramhasis/static/admin/src/app/ui/widgets/templates/SearchPane.html
@@ -3,9 +3,7 @@
   <div class="search-form">
     <form data-dojo-attach-point="labelSearchForm" data-dojo-attach-event="onsubmit: _search">
         <div class="large-10 columns">
-          <select data-dojo-attach-point="conceptSchemeSelect">
-            <option value="-1" selected disabled>Select thesaurus</option>
-          </select>
+          <select data-dojo-attach-point="conceptSchemeSelect"></select>
         </div>
         <div class="large-2 columns edit-scheme-button">
           <button type="button" class="button tiny" href="#/conceptscheme/edit" data-dojo-attach-point="editSchemeButton"


### PR DESCRIPTION
#883

This fixes disabled buttons when only 1 conceptscheme is present

Unfortunately, it is not reloading automatically. I'll create a new issue for this. The most annoying bug is gone, though.