### PR TITLE
Refactor the way routes are made.

### DIFF
--- a/atramhasis/__init__.py
+++ b/atramhasis/__init__.py
@@ -34,6 +34,8 @@ def includeme(config):
     for key, value in DEFAULT_SETTINGS.items():
         if key not in settings:
             settings[key] = value
+    # Regexes in path params clash with this validation.
+    settings["pyramid_openapi3.enable_endpoint_validation"] = False
     configure_session(config)
     config.include('pyramid_jinja2')
     config.include('pyramid_tm')
@@ -44,9 +46,10 @@ def includeme(config):
     config.include('pyramid_rewrite')
     config.include("pyramid_openapi3")
     config.include('atramhasis.routes')
+    # pyramid_skosprovider must be included after the atramhasis routes
+    # because it contains a regex in the path which consumes a lot of routes.
     config.include('pyramid_skosprovider')
     config.include('atramhasis.cache')
-    config.scan('pyramid_skosprovider')
 
     config.add_translation_dirs('atramhasis:locale/')
 

--- a/atramhasis/openapi.yaml
+++ b/atramhasis/openapi.yaml
@@ -142,7 +142,7 @@ paths:
           description: The identifier for a certain concept or collection.
           required: true
           schema:
-            type: integer
+            type: string
       responses:
         200:
           description: The concept was found in the conceptscheme.
@@ -172,7 +172,7 @@ paths:
           description: The identifier for a certain concept or collection.
           required: true
           schema:
-            type: integer
+            type: string
       requestBody:
         required: true
         description: Data to create concept or collection
@@ -222,7 +222,7 @@ paths:
           description: The identifier for a certain concept or collection.
           required: true
           schema:
-            type: integer
+            type: string
 
       responses:
         200:
@@ -692,7 +692,7 @@ paths:
           description: The identifier for a certain concept or collection.
           required: true
           schema:
-            type: integer
+            type: string
         - name: language
           in: query
           description: Returns the label with the corresponding language-tag if present.
@@ -748,7 +748,7 @@ paths:
           description: The identifier for a certain concept or collection.
           required: true
           schema:
-            type: integer
+            type: string
       responses:
         200:
           description: The concept/collection was found in the conceptscheme.
@@ -900,7 +900,7 @@ components:
       type: object
       properties:
         id:
-          type: integer
+          type: string
     Label:
       type: object
       properties:
@@ -952,7 +952,7 @@ components:
       type: object
       properties:
         id:
-          type: integer
+          type: string
         type:
           type: string
         labels:
@@ -990,7 +990,7 @@ components:
         - type: object
           properties:
             id:
-              type: integer
+              type: string
             uri:
               type: string
     ConceptTree:

--- a/atramhasis/rdf.py
+++ b/atramhasis/rdf.py
@@ -76,12 +76,12 @@ def _add_provider(graph, provider, dataseturi, request):
     graph.add((dataseturi, VOID.subset, pd))
     graph.add((pd, DCTERMS.identifier, Literal(pid)))
     graph.add((pd, VOID.rootResource, URIRef(provider.concept_scheme.uri)))
-    graph.add((pd, FOAF.homepage, URIRef(request.route_url('conceptscheme', scheme_id=pid))))
+    graph.add((pd, FOAF.homepage, URIRef(request.route_url('skosprovider.conceptscheme', scheme_id=pid))))
     _add_labels(graph, provider.concept_scheme, pd)
     _add_metadataset(graph, pd, metadataset)
     fmap = [
-        ('rdf', FORMATS.RDF_XML, 'atramhasis.rdf_full_export_ext'),
-        ('ttl', FORMATS.Turtle, 'atramhasis.rdf_full_export_turtle_ext')
+        ('rdf', FORMATS.RDF_XML, 'skosprovider.conceptscheme.cs.rdf'),
+        ('ttl', FORMATS.Turtle, 'skosprovider.conceptscheme.cs.ttl')
     ]
     for f in fmap:
         graph.add((pd, VOID.feature, f[1]))

--- a/atramhasis/routes.py
+++ b/atramhasis/routes.py
@@ -27,38 +27,21 @@ def includeme(config):
     config.add_static_view('static', 'static', cache_max_age=3600)
     config.add_route("sitemap", "/sitemap_index.xml")
 
+    # APIs with extensions instead of accept headers
     config.add_route('atramhasis.rdf_void_turtle_ext', pattern='/void.ttl', accept='text/turtle')
-    config.add_route('atramhasis.rdf_full_export_ext', pattern='/conceptschemes/{scheme_id}/c.rdf')
-    config.add_route('atramhasis.rdf_full_export_turtle_ext', pattern='/conceptschemes/{scheme_id}/c.ttl')
-    config.add_route('atramhasis.rdf_conceptscheme_export_ext', pattern='/conceptschemes/{scheme_id}.rdf')
-    config.add_route('atramhasis.rdf_conceptscheme_export_turtle_ext', pattern='/conceptschemes/{scheme_id}.ttl')
-    config.add_route('atramhasis.rdf_individual_export_ext', pattern='/conceptschemes/{scheme_id}/c/{c_id:.*}.rdf')
-    config.add_route('atramhasis.rdf_individual_export_turtle_ext', pattern='/conceptschemes/{scheme_id}/c/{c_id:.*}.ttl')
-    config.add_route('atramhasis.rdf_conceptscheme_jsonld_ext', pattern='/conceptschemes/{scheme_id}.jsonld')
-    config.add_route('atramhasis.rdf_individual_jsonld_ext', pattern='/conceptschemes/{scheme_id}/c/{c_id:.*}.jsonld')
+    config.add_route('skosprovider.conceptscheme.cs.rdf', pattern='/conceptschemes/{scheme_id}/c.rdf')
+    config.add_route('skosprovider.conceptscheme.cs.ttl', pattern='/conceptschemes/{scheme_id}/c.ttl')
+    config.add_route('skosprovider.conceptscheme.rdf', pattern='/conceptschemes/{scheme_id}.rdf')
+    config.add_route('skosprovider.conceptscheme.ttl', pattern='/conceptschemes/{scheme_id}.ttl')
+    config.add_route('skosprovider.conceptscheme.csv', pattern='/conceptschemes/{scheme_id}/c.csv')
+    config.add_route('skosprovider.c.rdf', pattern='/conceptschemes/{scheme_id}/c/{c_id:.*}.rdf')
+    config.add_route('skosprovider.c.ttl', pattern='/conceptschemes/{scheme_id}/c/{c_id:.*}.ttl')
 
-    config.add_route('conceptschemes', pattern='/conceptschemes', accept='text/html', request_method="GET")
-    config.add_route('conceptscheme', pattern='/conceptschemes/{scheme_id}', accept='text/html', request_method="GET")
-    config.add_route('concept', pattern='/conceptschemes/{scheme_id}/c/{c_id:.*}', accept='text/html',
-                     request_method="GET")
-    config.add_route('search_result', pattern='/conceptschemes/{scheme_id}/c', accept='text/html')
-    config.add_route('scheme_root', pattern='/conceptschemes/{scheme_id}/c/', accept='text/html')
+    # tree
     config.add_route('scheme_tree_html', pattern='/conceptschemes/{scheme_id}/tree', accept='text/html')
     config.add_route('scheme_tree', pattern='/conceptschemes/{scheme_id}/tree', accept='application/json')
 
-    config.add_route('search_result_export', pattern='/conceptschemes/{scheme_id}/c.csv')
-    config.add_route('atramhasis.edit_conceptscheme', pattern='/conceptschemes/{scheme_id}',
-                     accept='application/json', request_method='PUT')
-    config.add_route('atramhasis.get_conceptscheme', pattern='/conceptschemes/{scheme_id}', accept='application/json')
-    config.add_route('atramhasis.get_conceptschemes', pattern='/conceptschemes', accept='application/json')
-    config.add_route('atramhasis.get_concept', pattern='/conceptschemes/{scheme_id}/c/{c_id:.*}',
-                     accept='application/json', request_method="GET")
-    config.add_route('atramhasis.add_concept', pattern='/conceptschemes/{scheme_id}/c', accept='application/json',
-                     request_method="POST")
-    config.add_route('atramhasis.edit_concept', pattern='/conceptschemes/{scheme_id}/c/{c_id:.*}',
-                     accept='application/json', request_method="PUT")
-    config.add_route('atramhasis.delete_concept', pattern='/conceptschemes/{scheme_id}/c/{c_id:.*}',
-                     accept='application/json', request_method="DELETE")
+    # language
     config.add_route('atramhasis.list_languages', pattern='/languages', accept='application/json',
                      request_method="GET")
     config.add_route('atramhasis.get_language', pattern='/languages/{l_id}', accept='application/json',
@@ -68,33 +51,16 @@ def includeme(config):
     config.add_route('atramhasis.delete_language', pattern='/languages/{l_id}', accept='application/json',
                      request_method="DELETE")
     config.add_route('locale', '/locale')
-    config.add_route('labeltypes', '/labeltypes', accept='application/json', request_method="GET")
-    config.add_route('notetypes', '/notetypes', accept='application/json', request_method="GET")
 
+    # admin
     config.add_route('admin', '/admin')
     config.add_route('scheme_tree_invalidate', pattern='/admin/tree/invalidate/{scheme_id}', accept='application/json')
     config.add_route('tree_invalidate', pattern='/admin/tree/invalidate', accept='application/json')
 
-    config.add_route('atramhasis.rdf_full_export_turtle', pattern='/conceptschemes/{scheme_id}/c', accept='text/turtle')
-    config.add_route('atramhasis.rdf_full_export_turtle_x', pattern='/conceptschemes/{scheme_id}/c',
-                     accept='application/x-turtle')
-    config.add_route('atramhasis.rdf_full_export', pattern='/conceptschemes/{scheme_id}/c',
-                     accept='application/rdf+xml')
-    config.add_route('atramhasis.rdf_conceptscheme_export', pattern='/conceptschemes/{scheme_id}',
-                     accept='application/rdf+xml')
-    config.add_route('atramhasis.rdf_conceptscheme_export_turtle', pattern='/conceptschemes/{scheme_id}',
-                     accept='text/turtle')
-    config.add_route('atramhasis.rdf_conceptscheme_export_turtle_x', pattern='/conceptschemes/{scheme_id}',
-                     accept='application/x-turtle')
-    config.add_route('atramhasis.rdf_individual_export', pattern='/conceptschemes/{scheme_id}/c/{c_id:.*}',
-                     accept='application/rdf+xml')
-    config.add_route('atramhasis.rdf_individual_export_turtle', pattern='/conceptschemes/{scheme_id}/c/{c_id:.*}',
-                     accept='text/turtle')
-    config.add_route('atramhasis.rdf_individual_export_turtle_x', pattern='/conceptschemes/{scheme_id}/c/{c_id:.*}',
-                     accept='application/x-turtle')
-    config.add_route('atramhasis.rdf_conceptscheme_jsonld', pattern='/conceptschemes/{scheme_id}',
-                     accept='application/ld+json')
-    config.add_route('atramhasis.rdf_individual_jsonld', pattern='/conceptschemes/{scheme_id}/c/{c_id:.*}',
-                     accept='application/ld+json')
+    # providers
     config.add_route('atramhasis.providers', pattern='/providers')
     config.add_route('atramhasis.provider', pattern='/providers/{id}')
+
+    # other
+    config.add_route('labeltypes', '/labeltypes', accept='application/json', request_method="GET")
+    config.add_route('notetypes', '/notetypes', accept='application/json', request_method="GET")

--- a/atramhasis/routes.py
+++ b/atramhasis/routes.py
@@ -29,6 +29,7 @@ def includeme(config):
 
     # APIs with extensions instead of accept headers
     config.add_route('atramhasis.rdf_void_turtle_ext', pattern='/void.ttl', accept='text/turtle')
+    # The routes below extend the existing skosprovider routes with extensions
     config.add_route('skosprovider.conceptscheme.cs.rdf', pattern='/conceptschemes/{scheme_id}/c.rdf')
     config.add_route('skosprovider.conceptscheme.cs.ttl', pattern='/conceptschemes/{scheme_id}/c.ttl')
     config.add_route('skosprovider.conceptscheme.rdf', pattern='/conceptschemes/{scheme_id}.rdf')

--- a/atramhasis/templates/concept.jinja2
+++ b/atramhasis/templates/concept.jinja2
@@ -2,7 +2,7 @@
 {% block head %}
   {{ super() }}
   <meta name="og:type" content="website" />
-  <meta name="og:url" content="{{ request.route_url('concept', scheme_id=scheme_id, c_id=concept.concept_id) }}" />
+  <meta name="og:url" content="{{ request.route_url('skosprovider.c', scheme_id=scheme_id, c_id=concept.concept_id) }}" />
   <meta name="og:title" content="{{ concept.label(locale).label|safe }}" />
   {% if concept.notes|length > 0 %}
     <meta name="og:description" content="{{ concept.notes[0]|safe }}" />
@@ -13,7 +13,7 @@
   {% if concept.notes|length > 0 %}
     <meta name="twitter:description" content="{{ concept.notes[0]|safe }}" />
   {% endif %}
-  <link rel="canonical" href="{{ request.route_url('concept', scheme_id=scheme_id, c_id=concept.concept_id) }}" />
+  <link rel="canonical" href="{{ request.route_url('skosprovider.c', scheme_id=scheme_id, c_id=concept.concept_id) }}" />
 {% endblock %}
 {% block html_title %}{{ concept.label(locale).label|title }}{% endblock %}
 
@@ -31,9 +31,9 @@
       <div class="clearfix">
         <ul class="downloadtop right">
           <li>DOWNLOAD</li>
-          <li><a href="{{ request.route_path('atramhasis.rdf_individual_export_ext', scheme_id=scheme_id, c_id=concept.concept_id) }}">RDF/XML</a></li>
-          <li><a href="{{ request.route_path('atramhasis.rdf_individual_jsonld_ext', scheme_id=scheme_id, c_id=concept.concept_id) }}">JSON-LD</a></li>
-          <li><a href="{{ request.route_path('atramhasis.rdf_individual_export_turtle_ext', scheme_id=scheme_id, c_id=concept.concept_id) }}">N3/Turtle</a></li>
+          <li><a href="{{ request.route_path('skosprovider.c.rdf', scheme_id=scheme_id, c_id=concept.concept_id) }}">RDF/XML</a></li>
+          <li><a href="{{ request.route_path('skosprovider.c.jsonld', scheme_id=scheme_id, c_id=concept.concept_id) }}">JSON-LD</a></li>
+          <li><a href="{{ request.route_path('skosprovider.c.ttl', scheme_id=scheme_id, c_id=concept.concept_id) }}">N3/Turtle</a></li>
         </ul>
       </div>
       {% if concept %}
@@ -53,7 +53,7 @@
               <dd class="word-wrap-element"><a href="{{ concept.uri }}">{{ concept.uri }}</a></dd>
             {% endif %}
             <dt>schema</dt>
-            <dd><a href="{{ request.route_path('conceptscheme', scheme_id=scheme_id) }}">{{ get_conceptscheme_label(concept.conceptscheme, request.locale_name) }}</a></dd>
+            <dd><a href="{{ request.route_path('skosprovider.conceptscheme', scheme_id=scheme_id) }}">{{ get_conceptscheme_label(concept.conceptscheme, request.locale_name) }}</a></dd>
             {% if concept.labels %}
               {{ print_labels(concept.labels) }}
             {% endif %}

--- a/atramhasis/templates/conceptscheme.jinja2
+++ b/atramhasis/templates/conceptscheme.jinja2
@@ -2,7 +2,7 @@
 {% block head %}
   {{ super() }}
   <meta name="og:type" content="website" />
-  <meta name="og:url" content="{{ request.route_url('conceptscheme', scheme_id=conceptscheme.scheme_id) }}" />
+  <meta name="og:url" content="{{ request.route_url('skosprovider.conceptscheme', scheme_id=conceptscheme.scheme_id) }}" />
   <meta name="og:title" content="{{ conceptscheme.title }}" />
   {% if conceptscheme.notes|length > 0 %}
     <meta name="og:description" content="{{ conceptscheme.notes[0]|safe }}" />
@@ -13,7 +13,7 @@
   {% if conceptscheme.notes|length > 0 %}
     <meta name="twitter:description" content="{{ conceptscheme.notes[0]|safe }}" />
   {% endif %}
-  <link rel="canonical" href="{{ request.route_url('conceptscheme', scheme_id=conceptscheme.scheme_id) }}" />
+  <link rel="canonical" href="{{ request.route_url('skosprovider.conceptscheme', scheme_id=conceptscheme.scheme_id) }}" />
 {% endblock %}
 {% block html_title %}{{ conceptscheme.title }}{% endblock %}
 
@@ -29,11 +29,11 @@
       <div class="clearfix">
         <ul class="downloadtop right">
           <li>DOWNLOAD</li>
-          <li><a title="Download the scheme and it's top concepts in RDF/XML format." href="{{request.route_path('atramhasis.rdf_conceptscheme_export_ext', scheme_id=conceptscheme.scheme_id)}}">RDF/XML</a></li>
-          <li><a title="Download the scheme and it's top concepts in JSON-LD format." href="{{request.route_path('atramhasis.rdf_conceptscheme_jsonld_ext', scheme_id=conceptscheme.scheme_id)}}">JSON-LD</a></li>
-          <li><a title="Download the scheme and it's top concepts in N3/Turle format." href="{{request.route_path('atramhasis.rdf_conceptscheme_export_turtle_ext', scheme_id=conceptscheme.scheme_id)}}">N3/Turtle</a></li>
-          <li><a title="Download the scheme and all it's concepts and collections in RDF/XML format." href="{{request.route_path('atramhasis.rdf_full_export_ext', scheme_id=conceptscheme.scheme_id)}}">Full RDF/XML</a></li>
-          <li><a title="Download the scheme and all it's concepts and collections in N3/Turtle format." href="{{request.route_path('atramhasis.rdf_full_export_turtle_ext', scheme_id=conceptscheme.scheme_id)}}">Full N3/Turtle</a></li>
+          <li><a title="Download the scheme and it's top concepts in RDF/XML format." href="{{request.route_path('skosprovider.conceptscheme.rdf', scheme_id=conceptscheme.scheme_id)}}">RDF/XML</a></li>
+          <li><a title="Download the scheme and it's top concepts in JSON-LD format." href="{{request.route_path('skosprovider.conceptscheme.jsonld', scheme_id=conceptscheme.scheme_id)}}">JSON-LD</a></li>
+          <li><a title="Download the scheme and it's top concepts in N3/Turle format." href="{{request.route_path('skosprovider.conceptscheme.ttl', scheme_id=conceptscheme.scheme_id)}}">N3/Turtle</a></li>
+          <li><a title="Download the scheme and all it's concepts and collections in RDF/XML format." href="{{request.route_path('skosprovider.conceptscheme.cs.rdf', scheme_id=conceptscheme.scheme_id)}}">Full RDF/XML</a></li>
+          <li><a title="Download the scheme and all it's concepts and collections in N3/Turtle format." href="{{request.route_path('skosprovider.conceptscheme.cs.ttl', scheme_id=conceptscheme.scheme_id)}}">Full N3/Turtle</a></li>
           <li><a title="Open a printable scheme tree and all it's concepts." href="{{request.route_path('scheme_tree_html', scheme_id=conceptscheme.scheme_id)}}">Printable Tree</a></li>
         </ul>
       </div>

--- a/atramhasis/templates/conceptschemes.jinja2
+++ b/atramhasis/templates/conceptschemes.jinja2
@@ -12,7 +12,7 @@
       <div class="row">
         <h3 class="concept">{% trans %}select_scheme{% endtrans %}</h3>
         {% for item in conceptschemes %}
-          <div class="large-3 large-3-pad columns result-grid"><a href="{{ request.route_path('conceptscheme', scheme_id=item.id) }}"><h5>{{ get_conceptscheme_label(item.conceptscheme, request.locale_name) }}</h5> <span> [ ID : {{ item.id }} ]</span><br><small>{{ item.type }}</small></a></div>
+          <div class="large-3 large-3-pad columns result-grid"><a href="{{ request.route_path('skosprovider.conceptscheme', scheme_id=item.id) }}"><h5>{{ get_conceptscheme_label(item.conceptscheme, request.locale_name) }}</h5> <span> [ ID : {{ item.id }} ]</span><br><small>{{ item.type }}</small></a></div>
         {% endfor %}
       </div>
     </div>

--- a/atramhasis/templates/conceptschemes_overview.jinja2
+++ b/atramhasis/templates/conceptschemes_overview.jinja2
@@ -6,7 +6,7 @@
 <div class="large-12 columns">
   <div class="row" style="padding-top: 25px;">
     {% for item in conceptschemes %}
-      <div class="large-3 large-3-pad columns result-grid"><a href="{{ request.route_path('conceptscheme', scheme_id=item.id) }}"><h5>{{ get_conceptscheme_label(item.conceptscheme, request.locale_name) }}</h5> <span> [ ID : {{ item.id }} ]</span><br><small>{{ item.type }}</small></a></div>
+      <div class="large-3 large-3-pad columns result-grid"><a href="{{ request.route_path('skosprovider.conceptscheme', scheme_id=item.id) }}"><h5>{{ get_conceptscheme_label(item.conceptscheme, request.locale_name) }}</h5> <span> [ ID : {{ item.id }} ]</span><br><small>{{ item.type }}</small></a></div>
     {% endfor %}
   </div>
 </div>

--- a/atramhasis/templates/header-page.jinja2
+++ b/atramhasis/templates/header-page.jinja2
@@ -22,7 +22,7 @@
           <select id="scheme">
             <option value="" selected>{% trans %}select_scheme{% endtrans %}</option>
             {% for item in conceptschemes %}
-              <option {% if item.id == scheme_id %} selected="selected" {% endif %} value="{{ request.route_path('search_result', scheme_id=item.id) }}">
+              <option {% if item.id == scheme_id %} selected="selected" {% endif %} value="{{ request.route_path('skosprovider.conceptscheme.cs', scheme_id=item.id) }}">
                 {{ get_conceptscheme_label(item.conceptscheme, request.locale_name) }}
               </option>
             {% endfor %}

--- a/atramhasis/templates/macros.jinja2
+++ b/atramhasis/templates/macros.jinja2
@@ -5,7 +5,7 @@
       {%- for c in relaties|label_sort(language=locale) %}
         {%- set counter = counter + 1 %}
         <div class="large-3 large-3-pad columns result-grid" {% if counter == relaties|length %}style="float: left;"{% endif %}>
-          <a href="{{ request.route_path('concept', scheme_id = scheme_id, c_id = c.concept_id) }}"><h5>{{ c.label(locale).label }}</h5> <span> [ ID : {{ c.concept_id }} ]</span><br><small>{{ c.type }}</small></a>
+          <a href="{{ request.route_path('skosprovider.c', scheme_id = scheme_id, c_id = c.concept_id) }}"><h5>{{ c.label(locale).label }}</h5> <span> [ ID : {{ c.concept_id }} ]</span><br><small>{{ c.type }}</small></a>
         </div>
       {%- endfor %}
     </div>
@@ -127,7 +127,7 @@
   {%- set counter = 0  %}
   {%- for concept in concepts|label_sort(language=request.locale_name) %}
     {%- set counter = counter + 1 %}
-    <div class="large-3 large-3-pad columns result-grid" {% if counter == concepts|length %}style="float:left;"{% endif %}><a href="{{ request.route_path('concept', scheme_id= conceptscheme.scheme_id, c_id = concept.id) }}"><h5>{{ concept.label }}</h5> <span>[ id: {{ concept.id }} ]</span> <br><small>{{ concept.type }}</small></a></div>
+    <div class="large-3 large-3-pad columns result-grid" {% if counter == concepts|length %}style="float:left;"{% endif %}><a href="{{ request.route_path('skosprovider.c', scheme_id= conceptscheme.scheme_id, c_id = concept.id) }}"><h5>{{ concept.label }}</h5> <span>[ id: {{ concept.id }} ]</span> <br><small>{{ concept.type }}</small></a></div>
   {%- endfor %}
 {% endmacro %}
 
@@ -136,7 +136,7 @@
     {% set conceptLabel = request.skos_registry.get_provider(scheme_id).get_by_id(c['concept_id']) %}
     {% if conceptLabel and conceptLabel.label() %}
       <ul class="no_bullet">
-        <li class="cube"><a href="{{ request.route_path('atramhasis.get_concept', scheme_id=scheme_id, c_id=c['concept_id']) }}">
+        <li class="cube"><a href="{{ request.route_path('skosprovider.c', scheme_id=scheme_id, c_id=c['concept_id']) }}">
           {{ conceptLabel.label().label|capitalize() }}
         </a></li>
       </ul>

--- a/atramhasis/templates/search_form.jinja2
+++ b/atramhasis/templates/search_form.jinja2
@@ -10,7 +10,7 @@
       <select id="scheme">
         <option value="" selected>{% trans %}select_scheme{% endtrans %}</option>
         {% for item in conceptschemes %}
-          <option value="{{ request.route_path('search_result', scheme_id=item.id) }}">
+          <option value="{{ request.route_path('skosprovider.conceptscheme.cs', scheme_id=item.id) }}">
             {{ get_conceptscheme_label(item.conceptscheme, request.locale_name) }}
           </option>
         {% endfor %}

--- a/atramhasis/templates/search_result.jinja2
+++ b/atramhasis/templates/search_result.jinja2
@@ -15,7 +15,7 @@
         </ul>
       </div>
       {%- for c in concepts %}
-        <div class="large-3 large-3-pad columns result-grid"><a href="{{ request.route_path('concept', scheme_id= scheme_id, c_id = c.id) }}?type={{type}}&label={% if label is not none %}{{label}}{% endif %}"><h5>{{ c.label }}</h5> <span> [ ID : {{ c.id }} ]</span><br><small>{{ c.type }}</small></a></div>
+        <div class="large-3 large-3-pad columns result-grid"><a href="{{ request.route_path('skosprovider.c', scheme_id= scheme_id, c_id = c.id) }}?type={{type}}&label={% if label is not none %}{{label}}{% endif %}"><h5>{{ c.label }}</h5> <span> [ ID : {{ c.id }} ]</span><br><small>{{ c.type }}</small></a></div>
       {%- endfor %}
     </div>
   </div>

--- a/atramhasis/templates/subfooter-page.jinja2
+++ b/atramhasis/templates/subfooter-page.jinja2
@@ -22,7 +22,7 @@
       <h5>{% trans %}select_scheme{% endtrans %}</h5>
       <ul class="no_bullet">
         {% for c in conceptschemes %}
-          <li class="cube"><a href="{{ request.route_path('conceptscheme', scheme_id=c.id) }}">{{ c.conceptscheme.label(request.locale_name).label }}</a></li>
+          <li class="cube"><a href="{{ request.route_path('skosprovider.conceptscheme', scheme_id=c.id) }}">{{ c.conceptscheme.label(request.locale_name).label }}</a></li>
         {% endfor %}
       </ul>
     </div>

--- a/atramhasis/templates/tree.jinja2
+++ b/atramhasis/templates/tree.jinja2
@@ -213,7 +213,7 @@
       function openConcept(d) {
         d3.event.preventDefault();
         if (d.concept_id) {
-          var basepath = '{{ request.route_path('concept', scheme_id= scheme_id, c_id = '') }}';
+          var basepath = '{{ request.route_path('skosprovider.c', scheme_id= scheme_id, c_id = '') }}';
           window.location.href = basepath + d.concept_id +'?view_tree';
         }
         else {

--- a/atramhasis/views/crud.py
+++ b/atramhasis/views/crud.py
@@ -104,14 +104,12 @@ class AtramhasisCrud:
             )
 
     @audit
-    @view_config(route_name='atramhasis.get_conceptscheme', permission='view')
+    @view_config(route_name='skosprovider.conceptscheme', permission='view', request_method='GET')
     def get_conceptscheme(self):
-        if self.request.method == 'DELETE':
-            raise HTTPMethodNotAllowed
-        # is the same as the pyramid_skosprovider get_conceptscheme function, but wrapped with the audit function
+        # is the same as pyramid_skosprovider but wrapped with the audit decorator
         return ProviderView(self.request).get_conceptscheme()
 
-    @view_config(route_name='atramhasis.edit_conceptscheme', permission='edit')
+    @view_config(route_name='skosprovider.conceptscheme', permission='edit', request_method='PUT')
     def edit_conceptscheme(self):
         """
         Edit an existing concept
@@ -125,16 +123,8 @@ class AtramhasisCrud:
         self.request.response.status = '200'
         return conceptscheme
 
-    @view_config(route_name='atramhasis.get_conceptschemes', permission='view')
-    def get_conceptschemes(self):
-        if self.request.method == 'POST':
-            raise HTTPMethodNotAllowed
-        # is the same as the pyramid_skosprovider get_conceptscheme function, method not allowed included
-        from pyramid_skosprovider.views import ProviderView
-        return ProviderView(self.request).get_conceptschemes()
-
     @audit
-    @view_config(route_name='atramhasis.get_concept', permission='view')
+    @view_config(route_name='skosprovider.c', permission='view', request_method='GET')
     def get_concept(self):
         """
         Get an existing concept
@@ -156,7 +146,7 @@ class AtramhasisCrud:
         return concept
 
     @internal_providers_only
-    @view_config(route_name='atramhasis.add_concept', permission='edit')
+    @view_config(route_name='skosprovider.conceptscheme.cs', permission='edit', request_method='POST')
     def add_concept(self):
         """
         Add a new concept to a conceptscheme
@@ -217,7 +207,7 @@ class AtramhasisCrud:
         return from_thing(concept)
 
     @internal_providers_only
-    @view_config(route_name='atramhasis.edit_concept', permission='edit')
+    @view_config(route_name='skosprovider.c', permission='edit', request_method='PUT')
     def edit_concept(self):
         """
         Edit an existing concept
@@ -242,7 +232,7 @@ class AtramhasisCrud:
 
     @internal_providers_only
     @protected_operation
-    @view_config(route_name='atramhasis.delete_concept', permission='delete')
+    @view_config(route_name='skosprovider.c', permission='delete', request_method='DELETE')
     def delete_concept(self):
         """
         Delete an existing concept

--- a/atramhasis/views/rdf.py
+++ b/atramhasis/views/rdf.py
@@ -53,8 +53,8 @@ class AtramhasisRDF:
                 raise ConceptNotFoundException(self.c_id)
 
     @audit
-    @view_config(route_name='atramhasis.rdf_full_export')
-    @view_config(route_name='atramhasis.rdf_full_export_ext')
+    @view_config(route_name='skosprovider.conceptscheme.cs', accept='application/rdf+xml')
+    @view_config(route_name='skosprovider.conceptscheme.cs.rdf')
     def rdf_full_export(self):
         dump_location = self.request.registry.settings['atramhasis.dump_location']
         filename = os.path.join(dump_location, '%s-full.rdf' % self.scheme_id)
@@ -66,9 +66,9 @@ class AtramhasisRDF:
         )
 
     @audit
-    @view_config(route_name='atramhasis.rdf_full_export_turtle')
-    @view_config(route_name='atramhasis.rdf_full_export_turtle_x')
-    @view_config(route_name='atramhasis.rdf_full_export_turtle_ext')
+    @view_config(route_name='skosprovider.conceptscheme.cs', accept='text/turtle')
+    @view_config(route_name='skosprovider.conceptscheme.cs', accept='application/x-turtle')
+    @view_config(route_name='skosprovider.conceptscheme.cs.ttl')
     def rdf_full_export_turtle(self):
         dump_location = self.request.registry.settings['atramhasis.dump_location']
         filename = os.path.join(dump_location, '%s-full.ttl' % self.scheme_id)
@@ -80,8 +80,8 @@ class AtramhasisRDF:
         )
 
     @audit
-    @view_config(route_name='atramhasis.rdf_conceptscheme_export')
-    @view_config(route_name='atramhasis.rdf_conceptscheme_export_ext')
+    @view_config(route_name='skosprovider.conceptscheme', accept='application/rdf+xml')
+    @view_config(route_name='skosprovider.conceptscheme.rdf')
     def rdf_conceptscheme_export(self):
         graph = utils.rdf_conceptscheme_dumper(self.provider)
         response = Response(content_type='application/rdf+xml')
@@ -89,9 +89,9 @@ class AtramhasisRDF:
         response.content_disposition = 'attachment; filename="{}.rdf"'.format(str(self.scheme_id))
         return response
 
-    @view_config(route_name='atramhasis.rdf_conceptscheme_export_turtle')
-    @view_config(route_name='atramhasis.rdf_conceptscheme_export_turtle_x')
-    @view_config(route_name='atramhasis.rdf_conceptscheme_export_turtle_ext')
+    @view_config(route_name='skosprovider.conceptscheme', accept='text/turtle')
+    @view_config(route_name='skosprovider.conceptscheme', accept='application/x-turtle')
+    @view_config(route_name='skosprovider.conceptscheme.ttl')
     def rdf_conceptscheme_export_turtle(self):
         graph = utils.rdf_conceptscheme_dumper(self.provider)
         response = Response(content_type='text/turtle')
@@ -100,8 +100,8 @@ class AtramhasisRDF:
         return response
 
     @audit
-    @view_config(route_name='atramhasis.rdf_individual_export')
-    @view_config(route_name='atramhasis.rdf_individual_export_ext')
+    @view_config(route_name='skosprovider.c', accept='application/rdf+xml')
+    @view_config(route_name='skosprovider.c.rdf')
     def rdf_individual_export(self):
         graph = utils.rdf_c_dumper(self.provider, self.c_id)
         response = Response(content_type='application/rdf+xml')
@@ -110,9 +110,9 @@ class AtramhasisRDF:
         return response
 
     @audit
-    @view_config(route_name='atramhasis.rdf_individual_export_turtle')
-    @view_config(route_name='atramhasis.rdf_individual_export_turtle_x')
-    @view_config(route_name='atramhasis.rdf_individual_export_turtle_ext')
+    @view_config(route_name='skosprovider.c', accept='text/turtle')
+    @view_config(route_name='skosprovider.c', accept='application/x-turtle')
+    @view_config(route_name='skosprovider.c.ttl')
     def rdf_individual_export_turtle(self):
         graph = utils.rdf_c_dumper(self.provider, self.c_id)
         response = Response(content_type='text/turtle')
@@ -121,8 +121,8 @@ class AtramhasisRDF:
         return response
 
     @audit
-    @view_config(route_name='atramhasis.rdf_conceptscheme_jsonld', permission='view')
-    @view_config(route_name='atramhasis.rdf_conceptscheme_jsonld_ext', permission='view')
+    @view_config(route_name='skosprovider.conceptscheme', permission='view', accept='application/ld+json')
+    @view_config(route_name='skosprovider.conceptscheme.jsonld', permission='view')
     def get_conceptscheme_jsonld(self):
         conceptscheme = ProviderView(self.request).get_conceptscheme_jsonld()
         response = Response(content_type='application/ld+json')
@@ -131,8 +131,8 @@ class AtramhasisRDF:
         return response
 
     @audit
-    @view_config(route_name='atramhasis.rdf_individual_jsonld', permission='view')
-    @view_config(route_name='atramhasis.rdf_individual_jsonld_ext', permission='view')
+    @view_config(route_name='skosprovider.c', permission='view', accept='application/ld+json')
+    @view_config(route_name='skosprovider.c.jsonld', permission='view')
     def get_concept(self):
         concept = ProviderView(self.request).get_concept()
         response = Response(content_type='application/ld+json')

--- a/atramhasis/views/views.py
+++ b/atramhasis/views/views.py
@@ -57,7 +57,8 @@ def get_public_conceptschemes(skos_registry):
 
     return conceptschemes
 
-@view_defaults(accept='text/html')
+
+@view_defaults(accept='text/html', request_method='GET')
 class AtramhasisView:
     """
     This object groups HTML views part of the public user interface.
@@ -102,7 +103,7 @@ class AtramhasisView:
         """
         return {'conceptschemes': get_public_conceptschemes(self.skos_registry)}
 
-    @view_config(route_name='conceptschemes', renderer='atramhasis:templates/conceptschemes.jinja2')
+    @view_config(route_name='skosprovider.conceptschemes', renderer='atramhasis:templates/conceptschemes.jinja2')
     def conceptschemes_view(self):
         """
         Display a list of available conceptschemes.
@@ -110,7 +111,7 @@ class AtramhasisView:
         return {'conceptschemes': get_public_conceptschemes(self.skos_registry)}
 
     @audit
-    @view_config(route_name='conceptscheme', renderer='atramhasis:templates/conceptscheme.jinja2')
+    @view_config(route_name='skosprovider.conceptscheme', renderer='atramhasis:templates/conceptscheme.jinja2')
     def conceptscheme_view(self):
         """
         Display a single conceptscheme.
@@ -141,7 +142,7 @@ class AtramhasisView:
                 'locale': locale}
 
     @audit
-    @view_config(route_name='concept', renderer='atramhasis:templates/concept.jinja2')
+    @view_config(route_name='skosprovider.c', renderer='atramhasis:templates/concept.jinja2')
     def concept_view(self):
         """
         Display all about a single concept or collection.
@@ -173,7 +174,7 @@ class AtramhasisView:
                 concept_type = "Collection"
             else:
                 return Response('Thing without type: ' + str(c_id), status_int=500)
-            url = self.request.route_url('concept', scheme_id=scheme_id, c_id=c_id)
+            url = self.request.route_url('skosprovider.c', scheme_id=scheme_id, c_id=c_id)
             update_last_visited_concepts(self.request, {'label': c.label(locale).label, 'url': url})
             return {'concept': c, 'conceptType': concept_type, 'scheme_id': scheme_id,
                     'conceptschemes': conceptschemes, 'provider': provider,
@@ -181,7 +182,7 @@ class AtramhasisView:
         except NoResultFound:
             raise ConceptNotFoundException(c_id)
 
-    @view_config(route_name='search_result', renderer='atramhasis:templates/search_result.jinja2')
+    @view_config(route_name='skosprovider.conceptscheme.cs', renderer='atramhasis:templates/search_result.jinja2')
     def search_result(self):
         """
         Display search results
@@ -248,7 +249,7 @@ class AtramhasisView:
         return response
 
     @audit
-    @view_config(route_name='search_result_export', renderer='csv')
+    @view_config(route_name='skosprovider.conceptscheme.csv', renderer='csv')
     def results_csv(self):
         """
         Download search results in CSV format, allowing further processing.
@@ -352,11 +353,6 @@ class AtramhasisView:
             return urllib.parse.quote(str(concept_id), safe="")
         else:
             return parent_tree_id + "|" + urllib.parse.quote(str(concept_id), safe="")
-
-    @view_config(route_name='scheme_root', renderer='atramhasis:templates/concept.jinja2')
-    def results_tree_html(self):
-        scheme_id = self.request.matchdict['scheme_id']
-        return {'concept': None, 'conceptType': None, 'scheme_id': scheme_id}
 
 
 @view_defaults(accept='application/json', renderer='json')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ dependencies = [
     "skosprovider_sqlalchemy>=2.1.1",
     "skosprovider_rdf",
     "skosprovider_getty",
-    "pyramid_skosprovider",
+    "pyramid_skosprovider>=1.2.2",
     "language_tags",
     "jinja2 >=  3.0.0",
     "markupsafe",

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -175,7 +175,7 @@ pyramid-openapi3==0.19
     # via atramhasis (pyproject.toml)
 pyramid-rewrite==0.2
     # via atramhasis (pyproject.toml)
-pyramid-skosprovider==1.2.1
+pyramid-skosprovider==1.2.2
     # via atramhasis (pyproject.toml)
 pyramid-tm==2.5
     # via atramhasis (pyproject.toml)

--- a/requirements.txt
+++ b/requirements.txt
@@ -120,7 +120,7 @@ pyramid-openapi3==0.19
     # via atramhasis (pyproject.toml)
 pyramid-rewrite==0.2
     # via atramhasis (pyproject.toml)
-pyramid-skosprovider==1.2.1
+pyramid-skosprovider==1.2.2
     # via atramhasis (pyproject.toml)
 pyramid-tm==2.5
     # via atramhasis (pyproject.toml)

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -380,9 +380,6 @@ class RestFunctionalTests(FunctionalTests):
         self.assertEqual('200 OK', res.status)
         self.assertIsNotNone(res.json['id'])
         self.assertEqual(new_id, res.json['id'])
-        from skosprovider_sqlalchemy.models import Concept
-        concepten = self.session.query(Concept).all()
-        print()
 
     def test_delete_concept_not_found(self):
         res = self.testapp.delete('/conceptschemes/TREES/c/7895',
@@ -571,12 +568,6 @@ class RestFunctionalTests(FunctionalTests):
             "message": "resource urn:x-vioe:geography:9 is still in use, preventing operation",
             "referenced_in": ["urn:someobject", "http://test.test.org/object/2"]
         })
-
-    def test_method_not_allowed(self):
-        self.testapp.delete('/conceptschemes/TREES', headers=self._get_default_headers(),
-                            status=405)
-        self.testapp.post('/conceptschemes', headers=self._get_default_headers(),
-                          status=405)
 
     def test_get_conceptschemes(self):
         self.testapp.get('/conceptschemes', headers=self._get_default_headers(),
@@ -835,6 +826,13 @@ class RestFunctionalTests(FunctionalTests):
             },
             response.json
         )
+
+    def test_expand_concept(self):
+        res = self.testapp.get(
+            '/conceptschemes/TREES/c/1/expand', headers=self._get_default_headers(),
+            status=200,
+        )
+        self.assertEqual(res.json, ['1'])
 
 
 class TestCookieView(FunctionalTests):

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -249,7 +249,7 @@ class TestConceptView(unittest.TestCase):
     def setUp(self):
         self.config = testing.setUp()
         self.config.add_route(
-            "concept",
+            "skosprovider.c",
             pattern="/conceptschemes/{scheme_id}/c/{c_id}",
             accept="text/html",
             request_method="GET",
@@ -531,15 +531,6 @@ class TestHtmlTreeView(unittest.TestCase):
 
     def tearDown(self):
         testing.tearDown()
-
-    def test_passing_view(self):
-        self.request.skos_registry = self.regis
-        self.request.matchdict["scheme_id"] = "TREES"
-        atramhasisview = AtramhasisView(self.request)
-        response = atramhasisview.results_tree_html()
-        self.assertEqual(response["conceptType"], None)
-        self.assertEqual(response["concept"], None)
-        self.assertEqual(response["scheme_id"], "TREES")
 
 
 class TestAdminView(unittest.TestCase):


### PR DESCRIPTION
Atramhasis was duplicating a lot of routes declared
in pyramid_skosprovider and these conflicts caused
issues because the regex path params which use .*
would consume a bunch of routes which it should not.

Issue https://github.com/OnroerendErfgoed/atramhasis/issues/903