### PR TITLE
Potential fix for code scanning alert no. 17: DOM text reinterpreted as HTML

### DIFF
--- a/frontend/static/js/app.js
+++ b/frontend/static/js/app.js
@@ -4,7 +4,18 @@ $(document).foundation();
 
 // Function that makes the mobile menu work.
 $('#mobile-menu-select').change(function () {
-  window.location = $(this).val();
+  var selectedUrl = $(this).val();
+  try {
+    var parsedUrl = new URL(selectedUrl, window.location.origin);
+    if (
+      (parsedUrl.protocol === 'http:' || parsedUrl.protocol === 'https:') &&
+      parsedUrl.origin === window.location.origin
+    ) {
+      window.location = parsedUrl.pathname + parsedUrl.search + parsedUrl.hash;
+    }
+  } catch (e) {
+    // Ignore invalid URL values.
+  }
 });
 
 $(document).ready(function () {


### PR DESCRIPTION
Potential fix for [https://github.com/OnroerendErfgoed/atramhasis/security/code-scanning/17](https://github.com/OnroerendErfgoed/atramhasis/security/code-scanning/17)

The safest fix is to stop assigning raw DOM values directly to `window.location` and only allow navigation to trusted URLs (for example, same-origin relative paths, or a strict allowlist of origins/protocols).

For this file, the best minimal change is:
- In `frontend/static/js/app.js`, update the `#mobile-menu-select` change handler to:
  1. Read the selected value into a variable.
  2. Parse it with the `URL` constructor using `window.location.origin` as base.
  3. Allow navigation only if protocol is `http:` or `https:` and origin matches current origin.
  4. Navigate using the sanitized `pathname + search + hash`.
- Wrap parsing in `try/catch` to avoid runtime errors on malformed values.

This preserves functionality for normal internal links while preventing dangerous schemes or external redirects.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
