### PR TITLE
Fix pre-commit hooks and a docs code-block

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,8 +1,8 @@
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.11.3
+    rev: v0.11.10
     hooks:
-      - id: ruff
+      - id: ruff-check
         args: [--fix]
       - id: ruff-format
   - repo: local

--- a/docs/source/development.rst
+++ b/docs/source/development.rst
@@ -122,6 +122,7 @@ The dependencies are defined within pyproject.toml. There, you can add, modify, 
 Afterward, run pip-compile to generate the requirements files.
 
 .. code-block:: bash
+
     # Update pyproject.toml and compile requirements files as follows:
     $ ./scripts/compile-requirements.sh
 

--- a/frontend/static/js/app.js
+++ b/frontend/static/js/app.js
@@ -13,7 +13,7 @@ $('#mobile-menu-select').change(function () {
     ) {
       window.location = parsedUrl.pathname + parsedUrl.search + parsedUrl.hash;
     }
-  } catch (e) {
+  } catch {
     // Ignore invalid URL values.
   }
 });


### PR DESCRIPTION
Two pre-existing failures on `develop`, plus one tidy-up:

- Dropped the unused `catch` binding in `frontend/static/js/app.js` that failed `@typescript-eslint/no-unused-vars` (introduced by the CodeQL autofix in 1f4a9b34).
- Added the missing blank line after a `.. code-block:: bash` directive in `docs/source/development.rst`; sphinx errored on the file without it (4d759ebe).
- Tidy-up, not a fix: moved the ruff hook off the legacy `ruff` alias to `ruff-check`, which needs `ruff-pre-commit` >= `v0.11.10`. `develop` was not broken here — `ruff` still works upstream.
